### PR TITLE
recombine-10June-2

### DIFF
--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -414,6 +414,21 @@ zippyIntermed : Vect n ZZ -> Matrix n w ZZ -> Vect w ZZ
 zippyIntermed = (<\>)
 
 timesMatMatAsMultipleLinearCombos_EntryChariz : (vs : Matrix (S n') n ZZ) -> (xs : Matrix n w ZZ) -> Data.Vect.head (vs <> xs) = (Data.Vect.head vs) <\> xs
+timesMatMatAsMultipleLinearCombos_EntryChariz vs [] = ?timesMatMatAsMultipleLinearCombos_EntryCharizTriv
+timesMatMatAsMultipleLinearCombos_EntryChariz vs (xx::xxs) = ?timesMatMatAsMultipleLinearCombos_EntryChariz'
+
+timesMatMatAsMultipleLinearCombos_EntryCharizTriv = proof
+  intros
+  rewrite sym $ headtails vs
+  rewrite sym $ zeroVecVecId vs
+  exact Refl
+
+timesMatMatAsMultipleLinearCombos_EntryChariz' = proof
+  intros
+  rewrite sym $ headtails vs
+  exact Refl
+
+
 
 total
 zippyLemA : (the (Vect 0 ZZ) []) <\> (the (Matrix 0 w ZZ) []) = replicate w (Pos 0)


### PR DESCRIPTION
Adds proof of timesMatMatAsMultipleLinearCombos_EntryChariz, effectively proving the goal:
- "show that (<>) satisfies the property that the first argument scales the vectors of the second argument in n' various ways."

i.e., that (<>) agrees with the naiive definition of matrix multiplication in terms of linear combinations.
