### PR TITLE
spanslztrans work

### DIFF
--- a/Data/Matrix/LinearCombinations.idr
+++ b/Data/Matrix/LinearCombinations.idr
@@ -552,8 +552,8 @@ timesVectMatAsLinearCombo' = proof
 timesMatMatAsMultipleLinearCombos_EntryChariz : (vs : Matrix (S n') n ZZ) -> (xs : Matrix n w ZZ) -> Data.Vect.head (vs <> xs) = monoidsum $ zipWith (<#>) (Data.Vect.head vs) xs
 timesMatMatAsMultipleLinearCombos_EntryChariz vs xs = rewrite sym (timesVectMatAsLinearCombo (head vs) xs) in (timesMatMatAsTVecMat_EntryChariz vs xs)
 
-timesMatMatAsMultipleLinearCombos : (vs : Matrix (S n') n ZZ) -> (xs : Matrix n w ZZ) -> vs <> xs = map (\zs => monoidsum $ zipWith (<#>) zs xs) vs
-timesMatMatAsMultipleLinearCombos {n'=Z} (v::[]) xs = cong {f=(::[])} (timesMatMatAsMultipleLinearCombos_EntryChariz (v::[]) xs)
+timesMatMatAsMultipleLinearCombos : (vs : Matrix n' n ZZ) -> (xs : Matrix n w ZZ) -> vs <> xs = map (\zs => monoidsum $ zipWith (<#>) zs xs) vs
+timesMatMatAsMultipleLinearCombos {n'=Z} [] xs = Refl
 timesMatMatAsMultipleLinearCombos {n'=S predn'} (v::vs) xs = ?timesMatMatAsMultipleLinearCombos'
 
 timesMatMatAsMultipleLinearCombos' = proof

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ Other files show what other kind of theorems are needed, but about the wrong obj
 ## ZZModuleSpan
 
 Contents:
-* Definition of the *linearly spans* relation `spanslz` between two Vects of Vects of integers (where integers means inhabitants of Daata.ZZ).
+* Definition of the *linearly spans* relation `spanslz` between two Vects of Vects of integers (where integers means inhabitants of Data.ZZ).
 * Some definitions related to linear spans.
 * Proof of transitivity of `spanslz` using some unproved but known theorems.
+* Sketches of proof of `zippyScale` associativity in terms of the equivalent matrix multiplication associativity. `zippyScale` is shorthand for a form of linear combination of the rows of a matrix over multiple vectors, as dealt with and proved extensionally equal to matrix multiplication in Data.Matrix.LinearCombinations.
 
 ## Data.Matrix.LinearCombinations
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Other files show what other kind of theorems are needed, but about the wrong obj
 ## ZZModuleSpan
 
 Contents:
+* Definition of the *linearly spans* relation `spanslz` between two Vects of Vects of integers (where integers means inhabitants of Daata.ZZ).
 * Some definitions related to linear spans.
+* Proof of transitivity of `spanslz` using some unproved but known theorems.
 
 ## Data.Matrix.LinearCombinations
 

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -163,6 +163,9 @@ Same as above, but for lists of ZZ vectors specifically.
 zippyScale : Matrix n' n ZZ -> Matrix n w ZZ -> Matrix n' w ZZ
 zippyScale vs xs = map (\zs => monoidsum $ zipWith (<#>) zs xs) vs
 
+-- Inherited property from (<>) equality proven in Data.Matrix.LinearCombinations
+zippyScaleIsAssociative : xs `zippyScale` (ys `zippyScale` zs) = (xs `zippyScale` ys) `zippyScale` zs
+
 
 
 {-
@@ -289,6 +292,7 @@ spannedlzByZeroId' = proof
 Implicit naturals must be passed to the (spanslz)s in this type signature for the types of (vsx) in (the (spanslz xs ys) (vsx ** prvsx)) and (vsy) in (the (spanslz ys zs) (vsy ** prvsy)) to be inferred, even when these parameters are summoned in the definition.
 -}
 spanslztrans : {xs : Matrix na m ZZ} -> {ys : Matrix ni m ZZ} -> {zs : Matrix nu m ZZ} -> spanslz {n=na} {n'=ni} xs ys -> spanslz {n=ni} {n'=nu} ys zs -> spanslz xs zs
+{-
 spanslztrans {na=Z} {ni} {nu} {m} {xs} {ys} {zs} (vsx ** prvsx) (vsy ** prvsy) = ?spanslztrans_trivial_1
 	where
 		knwoledge : ys = neutral @{the (Monoid $ Matrix _ _ ZZ) %instance}
@@ -298,13 +302,13 @@ spanslztrans {na=Z} {ni} {nu} {m} {xs} {ys} {zs} (vsx ** prvsx) (vsy ** prvsy) =
 		spanxy' : spanslz xs ys
 		spanxy' = ( replicate ni [] ** replace {P=\hah => hah `zippyScale` xs = ys} (zeroVecVecId vsx) prvsx )
 		-}
-
+-}
 spanslztrans {na} {ni} {nu} {m} {xs} {ys} {zs} (vsx ** prvsx) (vsy ** prvsy) = ( spanslztrans_matrix ** spanslztrans_linearcombprop )
 	where
 		spanslztrans_matrix : Matrix nu na ZZ
 		spanslztrans_matrix = vsy <> vsx
 		spanslztrans_linearcombprop : spanslztrans_matrix `zippyScale` xs = zs
-		spanslztrans_linearcombprop = ?spanslztrans_linearcombprop'
+		spanslztrans_linearcombprop = trans (cong {f=(flip zippyScale) xs} $ timesMatMatAsMultipleLinearCombos vsy vsx) $ trans (sym $ zippyScaleIsAssociative {xs=vsy} {ys=vsx} {zs=xs}) $ trans (cong {f=zippyScale vsy} prvsx) prvsy
 
 {-
 In spanslztrans_trivial_1:

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -247,12 +247,38 @@ Implicit naturals must be passed to the (spanslz)s in this type signature for th
 -}
 spanslztrans : {xs : Matrix na m ZZ} -> {ys : Matrix ni m ZZ} -> {zs : Matrix nu m ZZ} -> spanslz {n=na} {n'=ni} xs ys -> spanslz {n=ni} {n'=nu} ys zs -> spanslz xs zs
 spanslztrans {na=Z} {ni} {nu} {m} {xs} {ys} {zs} (vsx ** prvsx) (vsy ** prvsy) = ?spanslztrans_trivial_1
+	where
+		knwoledge : ys = neutral @{the (Monoid $ Matrix _ _ ZZ) %instance}
+		knwoledge = spannedlzByZeroId $ replace {P=\t => spanslz t ys} (zeroVecEq {a=xs} {b=[]}) (vsx ** prvsx)
+		{-
+		-- Don't need this, really, but it took effort to make. Technique precedes that for above.
+		spanxy' : spanslz xs ys
+		spanxy' = ( replicate ni [] ** replace {P=\hah => hah `zippyScale` xs = ys} (zeroVecVecId vsx) prvsx )
+		-}
+
 spanslztrans {na} {ni} {nu} {m} {xs} {ys} {zs} (vsx ** prvsx) (vsy ** prvsy) = ( spanslztrans_matrix ** spanslztrans_linearcombprop )
 	where
 		spanslztrans_matrix : Matrix nu na ZZ
 		spanslztrans_matrix = vsy <> vsx
 		spanslztrans_linearcombprop : spanslztrans_matrix `zippyScale` xs = zs
 		spanslztrans_linearcombprop = ?spanslztrans_linearcombprop'
+
+{-
+In spanslztrans_trivial_1:
+
+spanslztrans {na=Z} {ni} {nu} {m} {xs} {ys} {zs} (vsx ** prvsx) (vsy ** prvsy) = ?spanslztrans_trivial_1
+
+REPL refuses to let us use our knowledge that (vsx = replicate ni 0) based on its type to rewrite the type of prvsx so we can extend this knowledge to a (spanslz) in (replicate ni 0) rather than (vsx).
+
+---
+
+spanslztrans_trivial_1> :t the (spanslz xs ys) ( (replicate ni []) ** replace {P=\hah => hah `zippyScale` xs = ys} (zeroVecVecId vsx) prvsx )
+
+(input):Type mismatch between
+        Vect m ZZ
+and
+        Vect (\ARG => multZ meth ARG) ZZ
+-}
 
 {-
 Have to plan the order of the rewrites just right so that you can apply (zeroVecVecId vsx) to the result of the (prvsx) substitution.

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -195,11 +195,12 @@ spansltrans xs ys
 Implicit naturals must be passed to the (spanslz)s in this type signature for the types of (vsx) in (the (spanslz xs ys) (vsx ** prvsx)) and (vsy) in (the (spanslz ys zs) (vsy ** prvsy)) to be inferred, even when these parameters are summoned in the definition.
 -}
 spanslztrans : {xs : Matrix na m ZZ} -> {ys : Matrix ni m ZZ} -> {zs : Matrix nu m ZZ} -> spanslz {n=na} {n'=ni} xs ys -> spanslz {n=ni} {n'=nu} ys zs -> spanslz xs zs
-spanslztrans {na} {ni} {nu} {m} (vsx ** prvsx) (vsy ** prvsy) = ( spanslztrans_matrix ** ?spanslztrans_linearcombprop )
+spanslztrans {na} {ni} {nu} {m} {xs} {zs} (vsx ** prvsx) (vsy ** prvsy) = ( spanslztrans_matrix ** spanslztrans_linearcombprop )
 	where
 		spanslztrans_matrix : Matrix nu na ZZ
 		spanslztrans_matrix = vsy <> vsx
--- spanslztrans (vsx ** prvsx) (vsy ** prvsy) = ( vsx <> vsy ** ?wahahaha )
+		spanslztrans_linearcombprop : spanslztrans_matrix `zippyScale` xs = zs
+		spanslztrans_linearcombprop = ?spanslztrans_linearcombprop'
 {-
 For reference to the types and proof intentions
 

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -191,16 +191,65 @@ spansltrans xs ys
 
 
 
+
+-- Something like this, but not.
+spanslzTail : {xs : Matrix (S predn) w ZZ} -> {ys : Matrix (S predn') w ZZ} -> spanslz xs ys -> spanslz (Data.Vect.tail xs) (Data.Vect.tail ys)
+spanslzTail {xs} {ys} (vs ** prvs) = ?spanslzTail'
+	where
+		tailnote : tail ys = map (\zs => monoidsum (zipWith (<#>) zs xs)) (tail vs)
+		tailnote = ?tailnote'
+		{-
+		tailnote' = proof
+		  intros
+		  exact trans (cong {f=Data.Vect.tail} $ sym prvs) _
+		  rewrite sym $ headtails vs
+		  exact Refl
+		-}
+
+spannedlzByZeroId : {xs : Matrix n m ZZ} -> spanslz [] xs -> xs=neutral @{the (Monoid $ Matrix _ _ ZZ) %instance}
+spannedlzByZeroId {xs=[]} (vs ** prvs) = Refl
+{-
+spannedlzByZeroId {xs=x::xs} ((v::vs) ** prvs) = cong {f=([]::)} (spannedlzByZeroId (tailedSpan (v::vs) (x::xs) prvs))
+	where
+		tailedSpan : (scals : Matrix (S _) (S _) ZZ) -> (vects : Matrix (S _) (S _) ZZ) -> scals `zippyScale` vects = rslt -> (tail scals) `zippyScale` (tail vects) = tail rslt
+		-- Not coherent! Should recurse somehow, though. Urgh.
+		-- Okay. Well the construction which replaces (xs) with its (tail) and produces a (spanslz) of the tail from one for (xs) would not actually take (v::vs) as an argument, it would take the (spanslz) for xs.
+-}
+{-
+spannedlzByZeroId {m} {xs} (vs ** prvs) with (vs `zippyScale` (the (Matrix _ m ZZ) []))
+	| va = rewrite sym (zeroVecVecId vs) in (the (va = xs) Refl)
+-}
+-- spannedlzByZeroId {xs} (vs ** prvs) = ?spannedlzByZeroId'
+-- spannedlzByZeroId {xs} (vs ** prvs) = rewrite sym (zeroVecVecId vs) in prvs
+
+
+
 {-
 Implicit naturals must be passed to the (spanslz)s in this type signature for the types of (vsx) in (the (spanslz xs ys) (vsx ** prvsx)) and (vsy) in (the (spanslz ys zs) (vsy ** prvsy)) to be inferred, even when these parameters are summoned in the definition.
 -}
 spanslztrans : {xs : Matrix na m ZZ} -> {ys : Matrix ni m ZZ} -> {zs : Matrix nu m ZZ} -> spanslz {n=na} {n'=ni} xs ys -> spanslz {n=ni} {n'=nu} ys zs -> spanslz xs zs
-spanslztrans {na} {ni} {nu} {m} {xs} {zs} (vsx ** prvsx) (vsy ** prvsy) = ( spanslztrans_matrix ** spanslztrans_linearcombprop )
+spanslztrans {na=Z} {ni} {nu} {m} {xs} {ys} {zs} (vsx ** prvsx) (vsy ** prvsy) = ?spanslztrans_trivial_1
+spanslztrans {na} {ni} {nu} {m} {xs} {ys} {zs} (vsx ** prvsx) (vsy ** prvsy) = ( spanslztrans_matrix ** spanslztrans_linearcombprop )
 	where
 		spanslztrans_matrix : Matrix nu na ZZ
 		spanslztrans_matrix = vsy <> vsx
 		spanslztrans_linearcombprop : spanslztrans_matrix `zippyScale` xs = zs
 		spanslztrans_linearcombprop = ?spanslztrans_linearcombprop'
+
+{-
+Have to plan the order of the rewrites just right so that you can apply (zeroVecVecId vsx) to the result of the (prvsx) substitution.
+Would be more efficient to show the 0-matrix-spanned theorem required.
+
+spanslztrans_trivial_1 = proof
+  intros
+  rewrite sym $ zeroVecEq {a=xs} {b=[]}
+  exact (replicate nu [] ** _)
+  compute
+  rewrite sym prvsy
+  rewrite sym prvsx
+  exact believe_me "qed"
+-}
+
 {-
 For reference to the types and proof intentions
 

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -155,7 +155,9 @@ spanslz {n} {n'} xs ys = (vs : Matrix n' n ZZ ** vs `zippyScale` xs = ys)
 Proof of relational properties of span
 
 i.e.,
-Relational: equivalence relation axioms
+Relational:
+* equivalence relation axioms
+* spanned by implies tail spanned by
 Algebraic: gcd and lcm divisibility relationships via Bezout's identity
 -}
 
@@ -191,30 +193,21 @@ spansltrans xs ys
 
 
 
-
--- Something like this, but not.
-spanslzTail : {xs : Matrix (S predn) w ZZ} -> {ys : Matrix (S predn') w ZZ} -> spanslz xs ys -> spanslz (Data.Vect.tail xs) (Data.Vect.tail ys)
-spanslzTail {xs} {ys} (vs ** prvs) = ?spanslzTail'
+spanslzTail : {xs : Matrix n w ZZ} -> {ys : Matrix (S predn') w ZZ} -> spanslz xs ys -> spanslz xs (Data.Vect.tail ys)
+spanslzTail {xs} {ys} (vs ** prvs) = (tail vs ** tailnote)
 	where
-		tailnote : tail ys = map (\zs => monoidsum (zipWith (<#>) zs xs)) (tail vs)
-		tailnote = ?tailnote'
-		{-
-		tailnote' = proof
-		  intros
-		  exact trans (cong {f=Data.Vect.tail} $ sym prvs) _
-		  rewrite sym $ headtails vs
-		  exact Refl
-		-}
+		tailnote : map (\zs => monoidsum (zipWith (<#>) zs xs)) (tail vs) = tail ys
+		tailnote = sym ?tailnote'
+
+tailnote' = proof
+  intros
+  exact trans (cong {f=Data.Vect.tail} $ sym prvs) _
+  rewrite sym $ headtails vs
+  exact Refl
 
 spannedlzByZeroId : {xs : Matrix n m ZZ} -> spanslz [] xs -> xs=neutral @{the (Monoid $ Matrix _ _ ZZ) %instance}
 spannedlzByZeroId {xs=[]} (vs ** prvs) = Refl
-{-
-spannedlzByZeroId {xs=x::xs} ((v::vs) ** prvs) = cong {f=([]::)} (spannedlzByZeroId (tailedSpan (v::vs) (x::xs) prvs))
-	where
-		tailedSpan : (scals : Matrix (S _) (S _) ZZ) -> (vects : Matrix (S _) (S _) ZZ) -> scals `zippyScale` vects = rslt -> (tail scals) `zippyScale` (tail vects) = tail rslt
-		-- Not coherent! Should recurse somehow, though. Urgh.
-		-- Okay. Well the construction which replaces (xs) with its (tail) and produces a (spanslz) of the tail from one for (xs) would not actually take (v::vs) as an argument, it would take the (spanslz) for xs.
--}
+-- spannedlzByZeroId {xs=x::xs} ((v::vs) ** prvs) = cong {f=(_::)} (spannedlzByZeroId $ spanslzTail ((v::vs)**prvs))
 {-
 spannedlzByZeroId {m} {xs} (vs ** prvs) with (vs `zippyScale` (the (Matrix _ m ZZ) []))
 	| va = rewrite sym (zeroVecVecId vs) in (the (va = xs) Refl)

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -292,66 +292,10 @@ spannedlzByZeroId' = proof
 Implicit naturals must be passed to the (spanslz)s in this type signature for the types of (vsx) in (the (spanslz xs ys) (vsx ** prvsx)) and (vsy) in (the (spanslz ys zs) (vsy ** prvsy)) to be inferred, even when these parameters are summoned in the definition.
 -}
 spanslztrans : {xs : Matrix na m ZZ} -> {ys : Matrix ni m ZZ} -> {zs : Matrix nu m ZZ} -> spanslz {n=na} {n'=ni} xs ys -> spanslz {n=ni} {n'=nu} ys zs -> spanslz xs zs
-{-
-spanslztrans {na=Z} {ni} {nu} {m} {xs} {ys} {zs} (vsx ** prvsx) (vsy ** prvsy) = ?spanslztrans_trivial_1
-	where
-		knwoledge : ys = neutral @{the (Monoid $ Matrix _ _ ZZ) %instance}
-		knwoledge = spannedlzByZeroId $ replace {P=\t => spanslz t ys} (zeroVecEq {a=xs} {b=[]}) (vsx ** prvsx)
-		{-
-		-- Don't need this, really, but it took effort to make. Technique precedes that for above.
-		spanxy' : spanslz xs ys
-		spanxy' = ( replicate ni [] ** replace {P=\hah => hah `zippyScale` xs = ys} (zeroVecVecId vsx) prvsx )
-		-}
--}
+
 spanslztrans {na} {ni} {nu} {m} {xs} {ys} {zs} (vsx ** prvsx) (vsy ** prvsy) = ( spanslztrans_matrix ** spanslztrans_linearcombprop )
 	where
 		spanslztrans_matrix : Matrix nu na ZZ
 		spanslztrans_matrix = vsy <> vsx
 		spanslztrans_linearcombprop : spanslztrans_matrix `zippyScale` xs = zs
 		spanslztrans_linearcombprop = trans (cong {f=(flip zippyScale) xs} $ timesMatMatAsMultipleLinearCombos vsy vsx) $ trans (sym $ zippyScaleIsAssociative {xs=vsy} {ys=vsx} {zs=xs}) $ trans (cong {f=zippyScale vsy} prvsx) prvsy
-
-{-
-In spanslztrans_trivial_1:
-
-spanslztrans {na=Z} {ni} {nu} {m} {xs} {ys} {zs} (vsx ** prvsx) (vsy ** prvsy) = ?spanslztrans_trivial_1
-
-REPL refuses to let us use our knowledge that (vsx = replicate ni 0) based on its type to rewrite the type of prvsx so we can extend this knowledge to a (spanslz) in (replicate ni 0) rather than (vsx).
-
----
-
-spanslztrans_trivial_1> :t the (spanslz xs ys) ( (replicate ni []) ** replace {P=\hah => hah `zippyScale` xs = ys} (zeroVecVecId vsx) prvsx )
-
-(input):Type mismatch between
-        Vect m ZZ
-and
-        Vect (\ARG => multZ meth ARG) ZZ
--}
-
-{-
-Have to plan the order of the rewrites just right so that you can apply (zeroVecVecId vsx) to the result of the (prvsx) substitution.
-Would be more efficient to show the 0-matrix-spanned theorem required.
-
-spanslztrans_trivial_1 = proof
-  intros
-  rewrite sym $ zeroVecEq {a=xs} {b=[]}
-  exact (replicate nu [] ** _)
-  compute
-  rewrite sym prvsy
-  rewrite sym prvsx
-  exact believe_me "qed"
--}
-
-{-
-For reference to the types and proof intentions
-
----
-
-spanslztrans {n} {n'} {n''} {m} (vsx ** prvsx) (vsy ** prvsy) = ?spanslztransPr
-	where
-		vsyTyper : Matrix n'' n' ZZ
-		vsyTyper = vsy
-
----
-
-spanslztrans {n} {n'} {xs} {ys} (vsx ** prvsx) (vsy ** prvsy) = ( the (Vect n' (Vect n ZZ)) _ ** rewrite sym prvsx in prvsy )
--}

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -194,12 +194,11 @@ spansltrans xs ys
 {-
 Implicit naturals must be passed to the (spanslz)s in this type signature for the types of (vsx) in (the (spanslz xs ys) (vsx ** prvsx)) and (vsy) in (the (spanslz ys zs) (vsy ** prvsy)) to be inferred, even when these parameters are summoned in the definition.
 -}
-spanslztrans : {xs : Matrix n m ZZ} -> {ys : Matrix n' m ZZ} -> {zs : Matrix n'' m ZZ} -> spanslz {n=n} {n'=n'} xs ys -> spanslz {n=n'} {n'=n''} ys zs -> spanslz xs zs
-spanslztrans {n} {n'} {n''} {m} (vsx ** prvsx) (vsy ** prvsy) = ( spanslztrans_matrix ** ?spanslztrans_linearcombprop )
+spanslztrans : {xs : Matrix na m ZZ} -> {ys : Matrix ni m ZZ} -> {zs : Matrix nu m ZZ} -> spanslz {n=na} {n'=ni} xs ys -> spanslz {n=ni} {n'=nu} ys zs -> spanslz xs zs
+spanslztrans {na} {ni} {nu} {m} (vsx ** prvsx) (vsy ** prvsy) = ( spanslztrans_matrix ** ?spanslztrans_linearcombprop )
 	where
-		spanslztrans_matrix : Matrix n'' n ZZ
-		spanslztrans_matrix = ?spanslztrans_matrix'
-		-- spanslztrans_matrix = vsy <> vsx
+		spanslztrans_matrix : Matrix nu na ZZ
+		spanslztrans_matrix = vsy <> vsx
 -- spanslztrans (vsx ** prvsx) (vsy ** prvsy) = ( vsx <> vsy ** ?wahahaha )
 {-
 For reference to the types and proof intentions

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -13,6 +13,17 @@ import Control.Algebra.NumericInstances
 
 
 {-
+Trivial lemmas
+-}
+
+vecHeadtailsEq : {xs,ys : Vect _ _} -> ( headeq : x = y ) -> ( taileq : xs = ys ) -> x::xs = y::ys
+vecHeadtailsEq {x} {xs} {ys} headeq taileq = trans (vectConsCong x xs ys taileq) $ cong {f=(::ys)} headeq
+-- Also a solid proof:
+-- vecHeadtailsEq {x} {xs} {ys} headeq taileq = trans (cong {f=(::xs)} headeq) $ replace {P=\l => l::xs = l::ys} headeq $ vectConsCong x xs ys taileq
+
+
+
+{-
 Definitions:
 * Verified module
 * Verified vector space
@@ -204,11 +215,6 @@ tailnote' = proof
   exact trans (cong {f=Data.Vect.tail} $ sym prvs) _
   rewrite sym $ headtails vs
   exact Refl
-
-vecHeadtailsEq : {xs,ys : Vect _ _} -> ( headeq : x = y ) -> ( taileq : xs = ys ) -> x::xs = y::ys
-vecHeadtailsEq {x} {xs} {ys} headeq taileq = trans (vectConsCong x xs ys taileq) $ cong {f=(::ys)} headeq
--- Also a solid proof:
--- vecHeadtailsEq {x} {xs} {ys} headeq taileq = trans (cong {f=(::xs)} headeq) $ replace {P=\l => l::xs = l::ys} headeq $ vectConsCong x xs ys taileq
 
 spannedlzByZeroId : {xs : Matrix n m ZZ} -> spanslz [] xs -> xs=neutral @{the (Monoid $ Matrix _ _ ZZ) %instance}
 spannedlzByZeroId {xs=[]} (vs ** prvs) = Refl

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -45,7 +45,50 @@ class (VerifiedRingWithUnity a, VerifiedAbelianGroup b, Module a b) => VerifiedM
 instance [vectModule] Module a b => Module a (Vect n b) where
 	(<#>) r = map (r <#>)
 
--- instance [matTimesMonoid] VerifiedRing r => VerifiedMonoid (Matrix n n r) where
+
+
+{-
+Definition:
+* Monoid/VerifiedMonoid instance matTimesMonoid/matTimesVerMonoid for matrix multiplication
+As desired in Data.Matrix.Algebraic
+
+-----
+
+When checking right hand side of matTimesVerSemigroup' with expected type
+        VerifiedSemigroup (Vect n (Vect n r))
+
+Can't resolve type class Semigroup (Vect n (Vect n r))
+
+-----
+
+instance [matTimesSemigroup] Ring r => Semigroup (Matrix n n r) where {}
+
+matTimesMonoid : Ring r => with matTimesSemigroup (Monoid (Matrix n n r))
+matTimesMonoid {r} {n} = ?matTimesMonoid'
+
+matTimesVerSemigroup : VerifiedRing r => with matTimesSemigroup (VerifiedSemigroup (Matrix n n r))
+matTimesVerSemigroup {r} {n} = matTimesVerSemigroup'
+	where
+		instance [matTimesVerSemigroup'] VerifiedSemigroup (Matrix n n r) where {
+				semigroupOpIsAssociative = ?semigroupOpIsAssociative_matTimesVerSemigroup
+			}
+
+matTimesVerMonoid : VerifiedRing r => with matTimesVerSemigroup (VerifiedMonoid (Matrix n n r))
+matTimesVerMonoid {r} {n} = matTimesVerMonoid'
+	where
+		instance [matTimesVerMonoid'] VerifiedMonoid (Matrix n n r) where {
+			monoidNeutralIsNeutralL = ?monoidNeutralIsNeutralL_matTimesVerMonoid
+			monoidNeutralIsNeutralR = ?monoidNeutralIsNeutralR_matTimesVerMonoid
+		}
+-}
+
+
+
+{-
+Associative property for matrix multiplication
+-}
+
+timesMatMatIsAssociative : Ring r => {l : Matrix _ _ r} -> {c : Matrix _ _ r} -> {r : Matrix _ _ r} -> l <> (c <> r) = l <> c <> r
 
 
 

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -205,8 +205,35 @@ tailnote' = proof
   rewrite sym $ headtails vs
   exact Refl
 
+vecHeadtailsEq : {xs,ys : Vect _ _} -> ( headeq : x = y ) -> ( taileq : xs = ys ) -> x::xs = y::ys
+vecHeadtailsEq {x} {xs} {ys} headeq taileq = trans (vectConsCong x xs ys taileq) $ cong {f=(::ys)} headeq
+-- Also a solid proof:
+-- vecHeadtailsEq {x} {xs} {ys} headeq taileq = trans (cong {f=(::xs)} headeq) $ replace {P=\l => l::xs = l::ys} headeq $ vectConsCong x xs ys taileq
+
 spannedlzByZeroId : {xs : Matrix n m ZZ} -> spanslz [] xs -> xs=neutral @{the (Monoid $ Matrix _ _ ZZ) %instance}
 spannedlzByZeroId {xs=[]} (vs ** prvs) = Refl
+spannedlzByZeroId {xs=x::xs} ((v::vs) ** prvs) = ?spannedlzByZeroId'
+
+spannedlzByZeroId' = proof
+  intros
+  exact vecHeadtailsEq (trans (sym $ cong {f=head} prvs) _) (spannedlzByZeroId $ spanslzTail ((v::vs)**prvs))
+  rewrite sym $ zeroVecEq {a=v} {b=[]}
+  exact Refl
+
+{-
+-- Works in REPL,
+-- if this is a little clearer.
+-- Difference is probably in inferring different implicit arguments to vecHeadtailsEq.
+spannedlzByZeroId' = proof
+  intros
+  exact vecHeadtailsEq _ (spannedlzByZeroId $ spanslzTail ((v::vs)**prvs))
+  exact trans (sym $ cong {f=head} prvs) _
+  -- compute
+  rewrite sym $ zeroVecEq {a=v} {b=[]}
+  -- compute
+  exact Refl
+-}
+
 -- spannedlzByZeroId {xs=x::xs} ((v::vs) ** prvs) = cong {f=(_::)} (spannedlzByZeroId $ spanslzTail ((v::vs)**prvs))
 {-
 spannedlzByZeroId {m} {xs} (vs ** prvs) with (vs `zippyScale` (the (Matrix _ m ZZ) []))

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -240,14 +240,6 @@ spannedlzByZeroId' = proof
   exact Refl
 -}
 
--- spannedlzByZeroId {xs=x::xs} ((v::vs) ** prvs) = cong {f=(_::)} (spannedlzByZeroId $ spanslzTail ((v::vs)**prvs))
-{-
-spannedlzByZeroId {m} {xs} (vs ** prvs) with (vs `zippyScale` (the (Matrix _ m ZZ) []))
-	| va = rewrite sym (zeroVecVecId vs) in (the (va = xs) Refl)
--}
--- spannedlzByZeroId {xs} (vs ** prvs) = ?spannedlzByZeroId'
--- spannedlzByZeroId {xs} (vs ** prvs) = rewrite sym (zeroVecVecId vs) in prvs
-
 
 
 {-


### PR DESCRIPTION
The work to prove transitivity `spanslztrans` of `spanslz`, the _linearly spans_ relation we'll be working with.

A structural change:
`zippyScale` is redefined to use the naiive definition in terms of linear combinations, instead of the matrix multiplication definition, for the sake of the proof statement (rather than algorithmic efficiency?).

The mixed use (see `spanslztrans` definition) of matrix multiplication and this linear combinations-based `zippyScale` might be a mistake in the end, but for now, `spanslztrans`, as a combinator, combines spanning sets of vectors through matrix multiplication, which should limit the rewriting required to go from the eventual (gcd) procedure to one where only matrix multiplication is used.

New relational properties:
- `spanslzTail`
- `spannedlzByZeroId`

Other new theorems:
- `vecHeadtailsEq`
- `timesMatMatIsAssociative`
- `zippyScaleIsAssociative`

Other new features:
- Domain of `timesMatMatAsMultipleLinearCombos` expanded from a positive-dimension argument to an arbitrary-dimension argument.
