### PR TITLE
Define ZZ gaussian elimination

### DIFF
--- a/FinOrdering.idr
+++ b/FinOrdering.idr
@@ -1,0 +1,50 @@
+module FinOrdering
+-- Classes (OrdRel, DecLT) are redundant with IntegerOrdering.idr
+
+import Data.Fin
+import Data.ZZ
+
+
+-- Note that unlike (=) the types do not inherently need to be ambiguous
+class OrdRel A where
+	LT : A -> A -> Type
+
+class (OrdRel s) => DecLT s where
+	decLT : (x1 : s) -> (x2 : s) -> Dec ( LT x1 x2 )
+
+data FinLTTy : (n : Nat) -> (i, j : Fin n) -> Type where
+	FinLTFZPos : FinLTTy (S (S n)) FZ (FS a)
+	FinLTIncrem : FinLTTy n a b -> FinLTTy (S n) (FS a) (FS b)
+
+instance OrdRel (Fin n) where
+	LT {n} = FinLTTy n
+
+total
+decLTFin : (n : Nat) -> (i, j : Fin n) -> Dec ( LT i j )
+decLTFin Z a _ = No (\x => FinZAbsurd a)
+decLTFin (S Z) a b = No cannit
+	where
+		cannit : FinLTTy (S Z) a b -> Void
+		cannit FinLTFZPos impossible
+		cannit (FinLTIncrem FinLTFZPos) impossible
+decLTFin (S (S n)) FZ FZ = No dontDoMeIn
+	where
+		dontDoMeIn : FinLTTy (S (S n)) FZ FZ -> Void
+		dontDoMeIn FinLTFZPos impossible
+		dontDoMeIn (FinLTIncrem t) impossible
+decLTFin (S (S n)) FZ (FS b) = Yes FinLTFZPos
+decLTFin (S (S n)) (FS a) FZ = No itsOver
+	where
+		itsOver : FinLTTy (S (S n)) (FS a) FZ -> Void
+		itsOver FinLTFZPos impossible
+		itsOver (FinLTIncrem t) impossible
+decLTFin (S (S n)) (FS a) (FS b) with (decLTFin (S n) a b)
+	| Yes w = Yes (FinLTIncrem w)
+	| No s = No (s' s)
+	where
+		s' : ( FinLTTy (S n) a b -> Void ) -> ( FinLTTy (S (S n)) (FS a) (FS b) -> Void )
+		s' avo FinLTFZPos impossible
+		s' avo (FinLTIncrem t) = avo t
+
+instance DecLT (Fin n) where
+	decLT {n} = decLTFin n

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Other files show what other kind of theorems are needed, but about the wrong obj
 ## ZZGaussianElimination
 
 Contents:
-* Scribbles about properties to be proven of gaussian elimination (the type signature of the function that performs the algorithm).
+* Declaration of gaussian elimination as an algorithm which converts a matrix into one in row echelon form which spans it. `gaussElimlz : (xs : Matrix n m ZZ) -> (gexs : Matrix n' m ZZ ** (gexs `spanslz` xs,rowEchelon gexs))`
+* Implementation of the second property, `rowEchelon`.
+* `leadingNonzeroCalc`, which takes a `Vect n ZZ` to its first index to a nonzero entry or a proof that all entries are zero.
 
 ## ZZModuleSpan
 
@@ -27,4 +29,5 @@ Most significant contents:
 ## FinOrdering
 
 Contents:
-* A(n) `LT` relation term meant for less-than relations, in an `OrdRel` class, and a `DecLT` class for decidable relations, where such an `OrdRel` whose `LT x y` is occupied will have a `decLT x y` giving an inhabitant and where unoccupied `decLT x y` will be a proof of this (some `LT x y -> Void`).
+* A(n) `LTRel` relation term meant for less-than relations, in an `OrdRel` class, and a `DecLT` class for decidable relations, where such an `OrdRel` whose `LTRel x y` is occupied will have a `decLT x y` giving an inhabitant and where unoccupied `decLT x y` will be a proof of this (some `LTRel x y -> Void`).
+* An instance of this for `Nat`, by which `Fin n` will be ordered indirectly through `finToNat`.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,13 @@
 
 Idris package looking to define, implement, and verify naiive Gaussian elimination over the integers in some system of linear algebra.
 
-ZZModuleSpan.idr and Data/Matrix/LinearCombinations.idr are the only usable files.
+ZZGaussianElimination.idr, ZZModuleSpan.idr, Data/Matrix/LinearCombinations.idr, & FinOrdering.idr are the only usable files.
 Other files show what other kind of theorems are needed, but about the wrong objects to be correct or to fit the system of linear algebra used in this package.
+
+## ZZGaussianElimination
+
+Contents:
+* Scribbles about properties to be proven of gaussian elimination (the type signature of the function that performs the algorithm).
 
 ## ZZModuleSpan
 
@@ -18,3 +23,8 @@ Contents:
 Most significant contents:
 * Proof, from some unproved basic facts, of definition of vector-matrix multiplication as a linear combination where the vectors under combination are rows of the matrix and the scalar weights are the entries of the same index to the vector under multiplication. `timesVectMatAsLinearCombo : (v : Vect n ZZ) -> (xs : Matrix n w ZZ) -> ( v <\> xs = monoidsum (zipWith (<#>) v xs) )`.
 * Proof from the above that the definition of matrix multiplication reduces to independent linear combinations of the row vectors of the righthand matrix. `timesMatMatAsMultipleLinearCombos : (vs : Matrix (S n') n ZZ) -> (xs : Matrix n w ZZ) -> vs <> xs = map (\zs => monoidsum $ zipWith (<#>) zs xs) vs`.
+
+## FinOrdering
+
+Contents:
+* A(n) `LT` relation term meant for less-than relations, in an `OrdRel` class, and a `DecLT` class for decidable relations, where such an `OrdRel` whose `LT x y` is occupied will have a `decLT x y` giving an inhabitant and where unoccupied `decLT x y` will be a proof of this (some `LT x y -> Void`).

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -1,3 +1,5 @@
+module ZZGaussianElimination
+
 import Control.Algebra
 import Control.Algebra.VectorSpace -- definition of module
 

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -1,0 +1,23 @@
+import Control.Algebra
+import Control.Algebra.VectorSpace -- definition of module
+
+import Data.Matrix
+import Data.Matrix.Algebraic -- module instances; from Idris 0.9.20
+
+import Data.ZZ
+import Control.Algebra.NumericInstances
+
+import ZZModuleSpan
+
+import FinOrdering
+
+
+
+rowReduced : (xs : Matrix n m ZZ) -> Type
+{-
+Something built from the same parts as this:
+-----
+rowReduced xs {n} {m} = {k : Fin n} -> {i, j : Fin m} -> (i `LT` j) -> (indices k i xs = Pos Z) -> (indices k j xs = Pos Z)
+-}
+
+gaussElimlz : (xs : Matrix n m ZZ) -> (gexs : Matrix n' m ZZ ** (gexs `spanslz` xs,rowReduced gexs))

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -47,7 +47,16 @@ leadingNonzeroCalc {n=S predn} (Pos Z::xs) with (leadingNonzeroCalc xs)
 				-> index ii (Pos Z::xs) = Pos Z
 			l_fn' {ii=FZ} precondit = Refl
 			l_fn' {ii=FS j} precondit = trans (l_fn_pr_skipup {v=Pos 0}) $ l_fn (fromLteSucc precondit)
--- leadingNonzeroCalc {n=S predn} (x::xs)
+leadingNonzeroCalc {n=S predn} (Pos (S k)::xs) = Right ( FZ ** ( void . succNotLTEzero, flip (replace {P=distinguish_Z_SZ}) () ) )
+	where
+		distinguish_Z_SZ : ZZ -> Type
+		distinguish_Z_SZ (Pos Z) = Void
+		distinguish_Z_SZ z = ()
+leadingNonzeroCalc {n=S predn} (NegS k::xs) = Right ( FZ ** ( void . succNotLTEzero, flip (replace {P=distinguish_Z_SZ}) () ) )
+	where
+		distinguish_Z_SZ : ZZ -> Type
+		distinguish_Z_SZ (Pos Z) = Void
+		distinguish_Z_SZ z = ()
 
 
 

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -15,11 +15,59 @@ import FinOrdering
 
 
 
-rowReduced : (xs : Matrix n m ZZ) -> Type
+downAndNotRightOfEntryImpliesZ : (xs : Matrix n m ZZ) -> (row : Fin n) -> (col : Fin m) -> Type
+downAndNotRightOfEntryImpliesZ xs nel mel {n} {m} = {i : Fin n} -> {j : Fin m} -> (finToNat nel `LTRel` finToNat i) -> (finToNat j `LTERel` finToNat mel) -> indices i j xs = Pos Z
 {-
-Something built from the same parts as this:
------
-rowReduced xs {n} {m} = {k : Fin n} -> {i, j : Fin m} -> (i `LT` j) -> (indices k i xs = Pos Z) -> (indices k j xs = Pos Z)
+Equivalent properties:
+1) map (take mel) (drop nel xs) = neutral
+2) (nel `LT` i) -> (j `LTE` mel) -> indices i j xs = Pos Z
+	# In pseudocode, because we decided not to use direct LT and LTE of Fins.
 -}
 
-gaussElimlz : (xs : Matrix n m ZZ) -> (gexs : Matrix n' m ZZ ** (gexs `spanslz` xs,rowReduced gexs))
+leadingNonzero : (v : Vect n ZZ) -> Type
+leadingNonzero {n} v = Either
+		(nel : Fin n **
+			( {i : Fin n}
+			-> finToNat i `LTRel` finToNat nel
+			-> index i v = Pos Z,
+			Not (index nel v = Pos Z) )
+		)
+		(v = neutral)
+
+leadingNonzeroCalc : (v : Vect n ZZ) -> leadingNonzero v
+
+rowEchelon : (xs : Matrix n m ZZ) -> Type
+{-
+Roughly this, but we get the error
+
+When checking left hand side of with block in ZZGaussianElimination.rowEchelon, ty:
+When checking argument l to constructor Prelude.Either.Left:
+        Attempting concrete match on polymorphic argument: MkSigma leadeln pr
+
+so I guess we have to go through some indirection first.
+---
+
+Also note there is a tricky part to matching on Right.
+
+We might have this
+
+> | Right _ = downAndNotRightOfEntryImpliesZ xs nel (last {n=predm})
+
+but that only works if we guarantee `m` has a predecessor `predm`. Else we should use
+
+> | Right _ = ()
+
+So, we should just simplify things and write
+
+{nelow : Fin n} -> (finToNat nel `LTRel` finToNat nelow) -> index nel xs = neutral
+
+---
+rowEchelon {n} {m} xs = (narg : Fin n) -> (ty narg)
+	where
+		ty : Fin n -> Type
+		ty nel with (leadingNonzeroCalc $ index nel xs)
+			| Left (leadeln ** pr) = downAndNotRightOfEntryImpliesZ xs nel leadeln
+			| Right _ = {nelow : Fin n} -> (finToNat nel `LTRel` finToNat nelow) -> index nel xs = neutral
+-}
+
+gaussElimlz : (xs : Matrix n m ZZ) -> (gexs : Matrix n' m ZZ ** (gexs `spanslz` xs,rowEchelon gexs))

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -41,18 +41,12 @@ leadingNonzeroCalc {n=S predn} (Pos Z::xs) with (leadingNonzeroCalc xs)
 	| Right ( predel ** (l_fn, r_pr) ) = Right ( FS predel ** (l_fn', r_pr) )
 		where
 			l_fn_pr_skipup : index (FS i) (v::vs) = index i vs
-			l_fn' : {i : Fin (S predn)}
-				-> finToNat i `LTRel` finToNat (FS predel)
-				-> index i (Pos Z::xs) = Pos Z
-			{-
-			-- When checking left hand side of with block in ZZGaussianElimination.leadingNonzeroCalc, l_fn':
-			-- i is not an implicit argument of with block in ZZGaussianElimination.leadingNonzeroCalc, l_fn'
-
-			l_fn' {i=FZ} _ = ?l_fn_pr_rhs_1
-			l_fn' {i=FS j} precondit = trans l_fn_pr_skipup $ l_fn $ fromLteSucc precondit
-
-			-- l_fn (fromLteSucc precondit) : index j xs = Pos 0
-			-}
+			l_fn_pr_skipup = Refl
+			l_fn' : {ii : Fin (S predn)}
+				-> finToNat ii `LTRel` finToNat (FS predel)
+				-> index ii (Pos Z::xs) = Pos Z
+			l_fn' {ii=FZ} precondit = Refl
+			l_fn' {ii=FS j} precondit = trans (l_fn_pr_skipup {v=Pos 0}) $ l_fn (fromLteSucc precondit)
 -- leadingNonzeroCalc {n=S predn} (x::xs)
 
 

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -35,19 +35,12 @@ leadingNonzero {n} v = Either
 		(v = neutral)
 
 leadingNonzeroCalc : (v : Vect n ZZ) -> leadingNonzero v
+leadingNonzeroCalc [] = Right Refl
+-- leadingNonzeroCalc (Z::xs) = 
+-- leadingNonzeroCalc (a::xs) =
 
-rowEchelon : (xs : Matrix n m ZZ) -> Type
 {-
-Roughly this, but we get the error
-
-When checking left hand side of with block in ZZGaussianElimination.rowEchelon, ty:
-When checking argument l to constructor Prelude.Either.Left:
-        Attempting concrete match on polymorphic argument: MkSigma leadeln pr
-
-so I guess we have to go through some indirection first.
----
-
-Also note there is a tricky part to matching on Right.
+There is a tricky part to matching on Right.
 
 We might have this
 
@@ -57,17 +50,17 @@ but that only works if we guarantee `m` has a predecessor `predm`. Else we shoul
 
 > | Right _ = ()
 
-So, we should just simplify things and write
+So, we just simplify things and write
 
-{nelow : Fin n} -> (finToNat nel `LTRel` finToNat nelow) -> index nel xs = neutral
-
----
+> | Right _ = {nelow : Fin n} -> (finToNat nel `LTRel` finToNat nelow) -> index nel xs = neutral
+-}
+rowEchelon : (xs : Matrix n m ZZ) -> Type
 rowEchelon {n} {m} xs = (narg : Fin n) -> (ty narg)
 	where
 		ty : Fin n -> Type
 		ty nel with (leadingNonzeroCalc $ index nel xs)
-			| Left (leadeln ** pr) = downAndNotRightOfEntryImpliesZ xs nel leadeln
+			| Left someNonZness with someNonZness
+				| (leadeln ** _) = downAndNotRightOfEntryImpliesZ xs nel leadeln
 			| Right _ = {nelow : Fin n} -> (finToNat nel `LTRel` finToNat nelow) -> index nel xs = neutral
--}
 
 gaussElimlz : (xs : Matrix n m ZZ) -> (gexs : Matrix n' m ZZ ** (gexs `spanslz` xs,rowEchelon gexs))


### PR DESCRIPTION
The work to define gaussian elimination, a definition which in and of itself has no holes, so that all properties that had to be expressed were defined / given implementations.
- Creates the module ZZGaussianElimination at ZZGaussianElimination.idr
- Creates the expression `gaussElimlz : (xs : Matrix n m ZZ) -> (gexs : Matrix n' m ZZ ** (spanslz gexs xs,rowEchelon gexs))`, which to give any implementation to is considered implementing gaussian elimination in an extended sense.
- Creates the module FinOrdering at FinOrdering.idr
- Reintroduces decidable orderings, in FinOrdering, for `Nat` in this case.
