### PR TITLE
Further spans properties

### DIFF
--- a/Control/Algebra/ZZVerifiedInstances.idr
+++ b/Control/Algebra/ZZVerifiedInstances.idr
@@ -1,0 +1,37 @@
+module Control.Algebra.ZZVerifiedInstances
+-- We will forego treating this as Control.Algebra.NumericVerifiedInstances
+
+import Data.ZZ
+import Control.Algebra
+import Classes.Verified
+import Control.Algebra.NumericInstances
+
+-- These can be proven through an isomorphism with the free ring on the empty type.
+
+instance VerifiedSemigroup ZZ where
+	semigroupOpIsAssociative = ?semigroupOpIsAssociative_ZZ
+
+instance VerifiedMonoid ZZ where {
+	monoidNeutralIsNeutralL = ?monoidNeutralIsNeutralL_ZZ
+	monoidNeutralIsNeutralR = ?monoidNeutralIsNeutralR_ZZ
+}
+
+instance VerifiedGroup ZZ where {
+	groupInverseIsInverseL = ?groupInverseIsInverseL_ZZ
+	groupInverseIsInverseR = ?groupInverseIsInverseR_ZZ
+}
+
+instance VerifiedAbelianGroup ZZ where {
+	abelianGroupOpIsCommutative = ?abelianGroupOpIsCommutative_ZZ
+}
+
+instance VerifiedRing ZZ where {
+	ringOpIsAssociative = ?ringOpIsAssociative_ZZ
+	ringOpIsDistributiveL = ?ringOpIsDistributiveL_ZZ
+	ringOpIsDistributiveR = ?ringOpIsDistributiveR_ZZ
+}
+
+instance VerifiedRingWithUnity ZZ where {
+	ringWithUnityIsUnityL = ?ringWithUnityIsUnityL_ZZ
+	ringWithUnityIsUnityR = ?ringWithUnityIsUnityR_ZZ
+}

--- a/Data/Matrix/AlgebraicVerified.idr
+++ b/Data/Matrix/AlgebraicVerified.idr
@@ -1,0 +1,93 @@
+module Data.Matrix.AlgebraicVerified
+
+import Control.Algebra
+import Control.Algebra.VectorSpace -- definition of module
+import Classes.Verified -- definition of verified algebras other than modules
+import Data.Matrix
+import Data.Matrix.Algebraic -- module instances; from Idris 0.9.20
+
+
+
+{-
+Definitions:
+* Verified module
+* Verified vector space
+
+Ripped from comments of Classes.Verified, commenting out there coincides with definition of module being in the separate module Control.Algebra.VectorSpace from Control.Algebra.
+-}
+
+
+
+class (VerifiedRingWithUnity a, VerifiedAbelianGroup b, Module a b) => VerifiedModule a b where
+  total moduleScalarMultiplyComposition : (x,y : a) -> (v : b) -> x <#> (y <#> v) = (x <.> y) <#> v
+  total moduleScalarUnityIsUnity : (v : b) -> unity {a} <#> v = v
+  total moduleScalarMultDistributiveWRTVectorAddition : (s : a) -> (v, w : b) -> s <#> (v <+> w) = (s <#> v) <+> (s <#> w)
+  total moduleScalarMultDistributiveWRTModuleAddition : (s, t : a) -> (v : b) -> (s <+> t) <#> v = (s <#> v) <+> (t <#> v)
+
+--class (VerifiedField a, VerifiedModule a b) => VerifiedVectorSpace a b where {}
+
+-- As desired in Data.Matrix.Algebraic
+instance [vectModule] Module a b => Module a (Vect n b) where
+	(<#>) r = map (r <#>)
+
+
+
+{-
+Definitions:
+* Verified module instance for Matrix n m ZZ.
+* Apparently the verified module instance for Vect n ZZ already exists.
+-}
+
+
+
+{-
+instance (VerifiedRingWithUnity a) => VerifiedSemigroup (Vect n a) where
+	semigroupOpIsAssociative = ?semigroupOpIsAssociative_Vect
+
+instance (VerifiedRingWithUnity a) => VerifiedMonoid (Vect n a) where {
+	monoidNeutralIsNeutralL = ?monoidNeutralIsNeutralL_Vect
+	monoidNeutralIsNeutralR = ?monoidNeutralIsNeutralR_Vect
+}
+
+instance (VerifiedRingWithUnity a) => VerifiedGroup (Vect n a) where {
+	groupInverseIsInverseL = ?groupInverseIsInverseL_Vect
+	groupInverseIsInverseR = ?groupInverseIsInverseR_Vect
+}
+
+instance (VerifiedRingWithUnity a) => VerifiedAbelianGroup (Vect n a) where {
+	abelianGroupOpIsCommutative = ?abelianGroupOpIsCommutative_Vect
+}
+
+instance (VerifiedRingWithUnity a) => VerifiedModule a (Vect n a) where {
+	moduleScalarMultiplyComposition = ?moduleScalarMultiplyComposition_Vect
+	moduleScalarUnityIsUnity = ?moduleScalarUnityIsUnity_Vect
+	moduleScalarMultDistributiveWRTVectorAddition = ?moduleScalarMultDistributiveWRTVectorAddition_Vect
+	moduleScalarMultDistributiveWRTModuleAddition = ?moduleScalarMultDistributiveWRTModuleAddition_Vect
+}
+-}
+
+
+
+instance (VerifiedRingWithUnity a) => VerifiedSemigroup (Matrix n m a) where
+	semigroupOpIsAssociative = ?semigroupOpIsAssociative_Mat
+
+instance (VerifiedRingWithUnity a) => VerifiedMonoid (Matrix n m a) where {
+	monoidNeutralIsNeutralL = ?monoidNeutralIsNeutralL_Mat
+	monoidNeutralIsNeutralR = ?monoidNeutralIsNeutralR_Mat
+}
+
+instance (VerifiedRingWithUnity a) => VerifiedGroup (Matrix n m a) where {
+	groupInverseIsInverseL = ?groupInverseIsInverseL_Mat
+	groupInverseIsInverseR = ?groupInverseIsInverseR_Mat
+}
+
+instance (VerifiedRingWithUnity a) => VerifiedAbelianGroup (Matrix n m a) where {
+	abelianGroupOpIsCommutative = ?abelianGroupOpIsCommutative_Mat
+}
+
+instance (VerifiedRingWithUnity a) => VerifiedModule a (Matrix n m a) where {
+	moduleScalarMultiplyComposition = ?moduleScalarMultiplyComposition_Vect
+	moduleScalarUnityIsUnity = ?moduleScalarUnityIsUnity_Mat
+	moduleScalarMultDistributiveWRTVectorAddition = ?moduleScalarMultDistributiveWRTVectorAddition_Mat
+	moduleScalarMultDistributiveWRTModuleAddition = ?moduleScalarMultDistributiveWRTModuleAddition_Mat
+}

--- a/LinCombHeadtailsEq.lidr
+++ b/LinCombHeadtailsEq.lidr
@@ -1,0 +1,141 @@
+> module ZZMSHeadtailsEq
+
+> import Data.Matrix.LinearCombinations
+> import ZZModuleSpan
+
+> import Control.Algebra
+> import Control.Algebra.VectorSpace -- definition of module
+> import Classes.Verified -- definition of verified algebras other than modules
+> import Data.Matrix
+> import Data.Matrix.Algebraic -- module instances; from Idris 0.9.20
+
+> import Data.ZZ
+
+
+
+# Contents
+* Introduction
+* vecSingletonReplicateEq
+* reduceMultUnderHeadTo1D
+* rewriteZipWithUnderTail
+* References
+
+
+
+# Introduction
+
+Suppose we have
+
+< vecHeadtailsEq : {xs,ys : Vect _ _} -> ( headeq : x = y ) -> ( taileq : xs = ys ) -> x::xs = y::ys
+
+Then we can replace efforts in proofs with this expression.
+
+These are proofs of equality of two Vects expressed in (x::xs) form, mainly inductive proofs:
+
+< vecSingletonReplicateEq : ((u : a) -> v=u) -> (xs : Vect n a) -> (xs = replicate n v)
+
+< reduceMultUnderHeadTo1D : {xxs : Matrix n (S m) ZZ} -> map Data.Vect.head (zipWith (<#>) (vv::vvs) (xx::xxs)) = zipWith (the (ZZ -> ZZ -> ZZ) (*)) (vv::vvs) (map Data.Vect.head (xx::xxs))
+< reduceMultUnderHeadTo1D_triv
+< reduceMultUnderHeadTo1D'
+
+< rewriteZipWithUnderTail : {scals : Vect n ZZ} -> {vects : Matrix n (S predw) ZZ} -> map Data.Vect.tail $ Data.Vect.zipWith (<#>) scals vects = Data.Vect.zipWith (<#>) scals (map Data.Vect.tail vects)
+< rewriteZipWithUnderTail'
+
+# vecSingletonReplicateEq
+
+Out of these, `vecSingletonReplicateEq` is the simplest to analyze the replacement.
+
+Let us write
+
+> vecSingletonReplicateEq_2 : ((u : a) -> v=u) -> (xs : Vect n a) -> (xs = replicate n v)
+> vecSingletonReplicateEq_2 f [] = Refl
+> vecSingletonReplicateEq_2 f (x::xs) = vecHeadtailsEq (sym $ f x) (vecSingletonReplicateEq_2 f xs)
+
+this improves the clarity of
+
+< vecSingletonReplicateEq : ((u : a) -> v=u) -> (xs : Vect n a) -> (xs = replicate n v)
+< vecSingletonReplicateEq f [] = Refl
+< vecSingletonReplicateEq f (x::xs) {v} = rewrite sym (f x) in cong {f=(v::)} (vecSingletonReplicateEq f xs)
+
+# reduceMultUnderHeadTo1D
+
+The ones in `reduceMultUnderHeadTo1D` are most aggregious. Let us write
+
+> reduceMultUnderHeadTo1D_2 : {xxs : Matrix n (S m) ZZ} -> map Data.Vect.head (zipWith (<#>) (vv::vvs) (xx::xxs)) = zipWith (the (ZZ -> ZZ -> ZZ) (*)) (vv::vvs) (map Data.Vect.head (xx::xxs))
+> reduceMultUnderHeadTo1D_2 {n=Z} {xxs=[]} {vvs=[]} = vecHeadtailsEq headMapChariz Refl
+> reduceMultUnderHeadTo1D_2 {n=S predn} {xxs=xxx::xxxs} {vvs=vvv::vvvs} = vecHeadtailsEq headMapChariz reduceMultUnderHeadTo1D_2
+> 
+
+Note the greater improvement of the proof for the case {n=Z} by pattern matching on the variables `xxs` and `vvs` rather than applying `zeroVecEq` to prove they're both [].
+
+Further, the corresponding finer-grained pattern matching in the longer-tailed cases eliminates the need for the second `vecHeadtailsEq` argument to be given by the proof
+
+< mapheads_eq_zipwith = proof
+<   intros
+<   rewrite sym $ headtails vvs
+<   rewrite sym $ headtails xxs
+<   exact reduceMultUnderHeadTo1D_2 {vv=head vvs} {vvs=tail vvs} {xx=head xxs} {xxs=tail xxs}
+
+as in
+
+< reduceMultUnderHeadTo1D_2 {n=S predn} {vv} {xx} = vecHeadtailsEq headMapChariz ?mapheads_eq_zipwith
+
+The original, however, is comparatively illegible
+
+< reduceMultUnderHeadTo1D : {xxs : Matrix n (S m) ZZ} -> map Data.Vect.head (zipWith (<#>) (vv::vvs) (xx::xxs)) = zipWith (the (ZZ -> ZZ -> ZZ) (*)) (vv::vvs) (map Data.Vect.head (xx::xxs))
+< reduceMultUnderHeadTo1D {n=Z} {vv} {xx} = ?reduceMultUnderHeadTo1D_triv
+< reduceMultUnderHeadTo1D {n=S predn} {vv} {xx} = ?reduceMultUnderHeadTo1D'
+< 
+< reduceMultUnderHeadTo1D_triv = proof
+<   intros
+<   rewrite sym (the (xxs = []) zeroVecEq)
+<   rewrite sym (the (vvs = []) zeroVecEq)
+<   compute
+<   exact cong {f=(::[])} _
+<   exact headMapChariz {xs=xx}
+< 
+< reduceMultUnderHeadTo1D' = proof
+<   intros
+<   -- Not required in the REPL: {f=multZ vv}
+<   exact trans (cong {f=(::(map head $ zipWith (<#>) vvs xxs))} $ headMapChariz {f=multZ vv} {xs=xx}) _
+<   compute
+<   exact cong {f=(::) (multZ vv (head xx))} _
+<   rewrite sym $ headtails vvs
+<   rewrite sym $ headtails xxs
+<   exact reduceMultUnderHeadTo1D {vv=head vvs} {vvs=tail vvs} {xx=head xxs} {xxs=tail xxs}
+
+# rewriteZipWithUnderTail
+
+Finally, `rewriteZipWithUnderTail` plays a full mind game with Idris to discuss one of these problems. We may write
+
+> rewriteZipWithUnderTail_2 : {scals : Vect n ZZ} -> {vects : Matrix n (S predw) ZZ} -> map Data.Vect.tail $ Data.Vect.zipWith (<#>) scals vects = Data.Vect.zipWith (<#>) scals (map Data.Vect.tail vects)
+> rewriteZipWithUnderTail_2 {scals=[]} {vects=[]} = Refl
+> rewriteZipWithUnderTail_2 {scals=z::zs} {vects=v::vs} = vecHeadtailsEq (rewrite sym $ sym $ headtails v in Refl) rewriteZipWithUnderTail_2
+
+whereas originally we had to write
+
+< rewriteZipWithUnderTail {scals=z::zs} {vects=v::vs} = ?rewriteZipWithUnderTail'
+< 
+< rewriteZipWithUnderTail' = proof
+<   intros
+<   let headv = map (z <.>) (tail v)
+<   exact trans _ (cong {f=(headv::)} $ rewriteZipWithUnderTail {scals=zs} {vects=vs})
+<   claim headeq tail (map (z<.>) v) = headv
+<   compute -- reduce the headv in the proposition to its value for prepping substitution
+<   unfocus
+<   rewrite sym headeq
+<   compute -- apply the (\x => headv::x) from the earlier cong
+<   exact Refl
+<   rewrite sym $ headtails v
+<   exact Refl
+
+
+
+# References
+
+* Idris 0.9.20 src: /test/regex007/A.lidr
+
+Notes
+
+* Idris 0.9.20 src: /samples/misc/reflection.idr
+* modules.rst

--- a/LinCombHeadtailsEq.lidr
+++ b/LinCombHeadtailsEq.lidr
@@ -1,4 +1,4 @@
-> module ZZMSHeadtailsEq
+> module LinCombHeadtailsEq
 
 > import Data.Matrix.LinearCombinations
 > import ZZModuleSpan

--- a/LinCombHeadtailsEq.lidr
+++ b/LinCombHeadtailsEq.lidr
@@ -41,6 +41,8 @@ These are proofs of equality of two Vects expressed in (x::xs) form, mainly indu
 < rewriteZipWithUnderTail : {scals : Vect n ZZ} -> {vects : Matrix n (S predw) ZZ} -> map Data.Vect.tail $ Data.Vect.zipWith (<#>) scals vects = Data.Vect.zipWith (<#>) scals (map Data.Vect.tail vects)
 < rewriteZipWithUnderTail'
 
+
+
 # vecSingletonReplicateEq
 
 Out of these, `vecSingletonReplicateEq` is the simplest to analyze the replacement.
@@ -56,6 +58,8 @@ this improves the clarity of
 < vecSingletonReplicateEq : ((u : a) -> v=u) -> (xs : Vect n a) -> (xs = replicate n v)
 < vecSingletonReplicateEq f [] = Refl
 < vecSingletonReplicateEq f (x::xs) {v} = rewrite sym (f x) in cong {f=(v::)} (vecSingletonReplicateEq f xs)
+
+
 
 # reduceMultUnderHeadTo1D
 
@@ -103,6 +107,8 @@ The original, however, is comparatively illegible
 <   rewrite sym $ headtails vvs
 <   rewrite sym $ headtails xxs
 <   exact reduceMultUnderHeadTo1D {vv=head vvs} {vvs=tail vvs} {xx=head xxs} {xxs=tail xxs}
+
+
 
 # rewriteZipWithUnderTail
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Contents: Declaration for `instance VerifiedRingWithUnity ZZ`
 ## Data.Matrix.AlgebraicVerified
 
 Definitions:
-** Verified module
-** Verified vector space
+* Verified module
+* Verified vector space
 
 Ripped from comments of Classes.Verified, commenting out there coincides with definition of module being in the separate module Control.Algebra.VectorSpace from Control.Algebra.
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,13 @@
 
 Idris package looking to define, implement, and verify naiive Gaussian elimination over the integers in some system of linear algebra.
 
-ZZGaussianElimination.idr, ZZModuleSpan.idr, Data/Matrix/LinearCombinations.idr, & FinOrdering.idr are the only usable files.
-Other files show what other kind of theorems are needed, but about the wrong objects to be correct or to fit the system of linear algebra used in this package.
+Ignore these files:
+* BezoutsIdentity.idr
+* IntegerArith.idr
+* IntegerGroupTheory.idr
+* IntegerOrdering.idr
+
+These show what other kind of theorems are needed, but about the wrong objects to be correct or to fit the system of linear algebra used in this package.
 
 ## ZZGaussianElimination
 
@@ -17,8 +22,10 @@ Contents:
 Contents:
 * Definition of the *linearly spans* relation `spanslz` between two Vects of Vects of integers (where integers means inhabitants of Data.ZZ).
 * Some definitions related to linear spans.
-* Proof of transitivity of `spanslz` using some unproved but known theorems.
+* Proof of transitivity and reflexivity of `spanslz` using some unproved but known theorems.
 * Sketches of proof of `zippyScale` associativity in terms of the equivalent matrix multiplication associativity. `zippyScale` is shorthand for a form of linear combination of the rows of a matrix over multiple vectors, as dealt with and proved extensionally equal to matrix multiplication in Data.Matrix.LinearCombinations.
+* Proof of `updateAtEquality : {ls : Matrix n k ZZ} -> {rs : Matrix k m ZZ} -> (updi : Fin n) -> (f : (i : Nat) -> Vect i ZZ -> Vect i ZZ) -> ( (la : Vect k ZZ) -> (f k la) <\> rs = f m $ la <\> rs ) -> zippyScale (updateAt updi (f k) ls) rs = updateAt updi (f m) (zippyScale ls rs)`, which lets you prove `vectMatLScalingCompatibility : {z : ZZ} -> {rs : Matrix k m ZZ} -> (z <#> la) <\> rs = z <#> (la <\> rs)` by a proof that works at least in the REPL, from which `spanRowScalelz : (z : ZZ) -> (updi : Fin n') -> spanslz xs ys -> spanslz xs (updateAt updi (z<#>) ys)` is proved.
+* Many propositions introduced. Towards the end of the file, after section "Proof of relational properties of span", the holes tend to be closer to known properties that will be used directly in the gaussian elimination algorithm, while towards the "Trivial lemmas and plumbing" section at the beginning of the file, the holes are generally strategies proposed for proving theorems about reordering vectors by a permutation, particularly the problem of reaching `spanslzAdditiveExchangeAt : (nel : Fin (S predn)) -> spanslz (updateAt nel (<+>(z<\>(deleteRow nel xs))) xs) xs` from `spanslzAdditiveExchange : spanslz ((y<+>(z<\>xs))::xs) (y::xs)`.
 
 ## Data.Matrix.LinearCombinations
 
@@ -31,3 +38,18 @@ Most significant contents:
 Contents:
 * A(n) `LTRel` relation term meant for less-than relations, in an `OrdRel` class, and a `DecLT` class for decidable relations, where such an `OrdRel` whose `LTRel x y` is occupied will have a `decLT x y` giving an inhabitant and where unoccupied `decLT x y` will be a proof of this (some `LTRel x y -> Void`).
 * An instance of this for `Nat`, by which `Fin n` will be ordered indirectly through `finToNat`.
+
+## Control.Algebra.ZZVerifiedInstances
+
+Contents: Declaration for `instance VerifiedRingWithUnity ZZ`
+
+## Data.Matrix.AlgebraicVerified
+
+Definitions:
+** Verified module
+** Verified vector space
+
+Ripped from comments of Classes.Verified, commenting out there coincides with definition of module being in the separate module Control.Algebra.VectorSpace from Control.Algebra.
+
+Declarations:
+* Verified module instance for `VerifiedRingWithUnity a => Matrix n m a`.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Other files show what other kind of theorems are needed, but about the wrong obj
 ## ZZGaussianElimination
 
 Contents:
-* Declaration of gaussian elimination as an algorithm which converts a matrix into one in row echelon form which spans it. `gaussElimlz : (xs : Matrix n m ZZ) -> (gexs : Matrix n' m ZZ ** (spanslz gexs xs,rowEchelon gexs))`
+* Declaration of gaussian elimination as an algorithm which converts a matrix into one in row echelon form which spans it. `gaussElimlz : (xs : Matrix n m ZZ) -> (gexs : Matrix n' m ZZ ** (spanslz gexs xs, spanslz xs gexs, rowEchelon gexs))`
 * Implementation of the second property, `rowEchelon`.
 * `leadingNonzeroCalc`, which takes a `Vect n ZZ` to its first index to a nonzero entry or a proof that all entries are zero.
 

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -8,6 +8,7 @@ import Data.Matrix.Algebraic -- module instances; from Idris 0.9.20
 
 import Data.ZZ
 import Control.Algebra.NumericInstances
+import Control.Algebra.ZZVerifiedInstances
 
 import ZZModuleSpan
 

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -85,4 +85,4 @@ rowEchelon {n} {m} xs = (narg : Fin n) -> (ty narg)
 				| (leadeln ** _) = downAndNotRightOfEntryImpliesZ xs nel leadeln
 			| Left _ = {nelow : Fin n} -> (finToNat nel `LTRel` finToNat nelow) -> index nel xs = neutral
 
-gaussElimlz : (xs : Matrix n m ZZ) -> (gexs : Matrix n' m ZZ ** (gexs `spanslz` xs,rowEchelon gexs))
+gaussElimlz : (xs : Matrix n m ZZ) -> (gexs : Matrix n' m ZZ ** (gexs `spanslz` xs, xs `spanslz` gexs, rowEchelon gexs))

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -12,6 +12,8 @@ import Data.ZZ
 import Control.Algebra.NumericInstances
 import Control.Algebra.ZZVerifiedInstances
 
+import Control.Isomorphism
+
 
 
 {-
@@ -286,7 +288,7 @@ Algebraic:
 * gcd and lcm divisibility relationships via Bezout's identity
 * additive updates to the spanning set that preserve span
 Reordering lemmas:
-* Master: (sigma : Bijection (Fin n)) -> spanslz (zipWith (index . (runBijection sigma)) range xs) xs
+* Master: permPreservesSpanslz : (sigma : Iso (Fin n) (Fin n)) -> spanslz (vectPermTo sigma xs) xs
 * Minimal for above: spanslz (x::y::zs) (y::x::zs)
 ** Requires knowledge that every permutation of (Fin n) is built up from pair swaps and that this corresponds to the special case of Master for such a permutation.
 ** Note that extension of special cases to those for the permutations' composites follows from spanslztrans together with (runBijection (sigma . tau) = (runBijection sigma) . (runBijection tau)).
@@ -515,3 +517,12 @@ spanslzSubtractivePreservation : spanslz (y::xs) ((y<->(z<\>xs))::xs)
 {-
 Implication of bispannability: Transformations of this form preserve the span of the vectors, the span of both sides of the transformation is the same ZZ-submodule of ZZ^n.
 -}
+
+
+
+vectPermTo : Iso (Fin n) (Fin n) -> Vect n a -> Vect n a
+vectPermTo (MkIso to from toFrom fromTo) {n} {a} xs = map (((flip index) xs) . to) range
+
+permPreservesSpanslz : (sigma : Iso (Fin n) (Fin n)) -> spanslz (vectPermTo sigma xs) xs
+
+permPreservesSpannedbylz : (sigma : Iso (Fin n) (Fin n)) -> spanslz xs (vectPermTo sigma xs)

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -507,3 +507,11 @@ spanslzAdditiveExchange2 : spanslz xs ys -> spanslz ((zs<+>ys)++xs) (zs++xs)
 
 spanslzSubtractiveExchange2 : spanslz xs ys -> spanslz ((zs<->ys)++xs) (zs++xs)
 -}
+
+spanslzAdditivePreservation : spanslz (y::xs) ((y<+>(z<\>xs))::xs)
+
+spanslzSubtractivePreservation : spanslz (y::xs) ((y<->(z<\>xs))::xs)
+
+{-
+Implication of bispannability: Transformations of this form preserve the span of the vectors, the span of both sides of the transformation is the same ZZ-submodule of ZZ^n.
+-}

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -366,16 +366,42 @@ spanslzrefl = ( Id ** zippyScaleIdLeftNeutral _ )
 
 
 
-updateAtEquality : {ls : Matrix n k ZZ} -> {rs : Matrix k m ZZ} -> (updi : Fin n) -> (f : (i : Nat) -> Vect i ZZ -> Vect i ZZ) -> (updateAt updi (f k) ls) `zippyScale` rs = updateAt updi (f m) (ls `zippyScale` rs)
-updateAtEquality {ls=[]} updi f = FinZElim updi
-updateAtEquality {ls=l::ls} FZ f = ?updateAtEquality'
-updateAtEquality {ls=l::ls} (FS penupdi) f = vecHeadtailsEq Refl $ updateAtEquality penupdi f
+updateAtEquality : {ls : Matrix n k ZZ} -> {rs : Matrix k m ZZ} -> (updi : Fin n) -> (f : (i : Nat) -> Vect i ZZ -> Vect i ZZ) -> ( (la : Vect k ZZ) -> (f k la) <\> rs = f m $ la <\> rs ) -> (updateAt updi (f k) ls) `zippyScale` rs = updateAt updi (f m) (ls `zippyScale` rs)
+updateAtEquality {ls=[]} updi f fnpreq = FinZElim updi
+updateAtEquality {ls=l::ls} {rs} FZ f fnpreq = vecHeadtailsEq {xs=tail $ (l::ls) `zippyScale` rs} ( trans (sym $ timesVectMatAsLinearCombo (f _ l) rs) $ trans (fnpreq l) $ cong {f=f _} $ timesVectMatAsLinearCombo l rs ) Refl
+updateAtEquality {ls=l::ls} (FS penupdi) f fnpreq = vecHeadtailsEq Refl $ updateAtEquality penupdi f fnpreq
+
+-- Note the relationship to bilinearity of matrix multiplication
+vectMatLScalingCompatibility : {z : ZZ} -> {rs : Matrix k m ZZ} -> (z <#> la) <\> rs = z <#> (la <\> rs)
+vectMatLScalingCompatibility {z} {la} {rs} = ?vectMatLScalingCompatibility_rhs
+
+{-
+-- Works in REPL, untested otherwise
+vectMatLScalingCompatibility_rhs = proof
+  intros
+  claim vectmatLiftId1 (z <#> la) <\> rs = head $ (row $ z <#> la) <> rs
+  unfocus
+  claim moveScaleOutsideRow row (z <#> la) = z <#> (row la)
+  unfocus
+  claim chScaleOutsideTimes (row (z <#> la)) <> rs = z <#> ((row la) <> rs)
+  unfocus
+  exact trans vectmatLiftId1 $ cong {f=head} chScaleOutsideTimes
+  trivial
+  unfocus
+  exact trans (cong {f=(<> rs)} moveScaleOutsideRow) _
+  trivial
+  compute
+  claim scalMatMatCompat (scal : ZZ) -> {nu, ka, mu : Nat} -> (xs : Matrix nu ka ZZ) -> (ys : Matrix ka mu ZZ) -> (scal <#> xs) <> ys = scal <#> (xs <> ys)
+  unfocus
+  exact scalMatMatCompat z (row la) rs
+  exact ?timesScalarLeftCommutesWithTimesMatRight
+-}
 
 spanRowScalelz : (z : ZZ) -> (updi : Fin n') -> spanslz xs ys -> spanslz xs (updateAt updi (z<#>) ys)
 spanRowScalelz z updi (vs ** prvs) {xs} = (updateAt updi (z<#>) vs ** trans scaleMain $ rewrite sym prvs in Refl)
 	where
 		scaleMain : (updateAt updi (z<#>) vs) `zippyScale` xs = updateAt updi (z<#>) (vs `zippyScale` xs)
-		scaleMain = updateAtEquality updi ( \i => (z<#>) )
+		scaleMain = updateAtEquality updi ( \i => (z<#>) ) ( \la => vectMatLScalingCompatibility {la=la} )
 
 
 
@@ -423,3 +449,7 @@ spanSub {xs} {ys} {zs} {n} {n'} {w} prxy prxz
 		| (vs ** pr) = ?ajdnjfka
 		-- | (vs ** pr) = (vs ** cong {f=spanslz xs} $ rewriteMultInvMat (the ZZ unity) pr)
 -}
+
+
+
+---

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -282,7 +282,17 @@ i.e.,
 Relational:
 * equivalence relation axioms
 * spanned by implies tail spanned by
-Algebraic: gcd and lcm divisibility relationships via Bezout's identity
+Algebraic:
+* gcd and lcm divisibility relationships via Bezout's identity
+* additive updates to the spanning set that preserve span
+Reordering lemmas:
+* Master: (sigma : Bijection (Fin n)) -> spanslz (zipWith (index . (runBijection sigma)) range xs) xs
+* Minimal for above: spanslz (x::y::zs) (y::x::zs)
+** Requires knowledge that every permutation of (Fin n) is built up from pair swaps and that this corresponds to the special case of Master for such a permutation.
+** Note that extension of special cases to those for the permutations' composites follows from spanslztrans together with (runBijection (sigma . tau) = (runBijection sigma) . (runBijection tau)).
+* spanslz (xs++ys) (ys++xs)
+Mixed:
+* compatibility with combining sets spanned or spanning (list concatenation is algebraic)
 -}
 
 
@@ -460,4 +470,40 @@ spanSub {xs} {ys} {zs} {n} {n'} {w} prxy prxz
 
 
 
----
+mergeSpannedLZs : spanslz xs ys -> spanslz xs zs -> spanslz xs (ys++zs)
+
+spanslzRowTimesSelf : spanslz xs [v<\>xs]
+
+extendSpanningLZsByPreconcatTrivially : spanslz xs ys -> spanslz (zs++xs) ys
+
+extendSpanningLZsByPostconcatTrivially : spanslz xs ys -> spanslz (xs++zs) ys
+
+concatSpansRellz : spanslz xs zs -> spanslz ys ws -> spanslz (xs++ys) (zs++ws)
+
+
+
+spanslzAdditiveExchange : spanslz ((y<+>(z<\>xs))::xs) (y::xs)
+
+spanslzSubtractiveExchange : spanslz ((y<->(z<\>xs))::xs) (y::xs)
+
+{-
+Should actually be as follows, as it will make the proof easier:
+
+spanslzAdditiveExchange : spanslz ((y<+>(monoidsum $ zipWith (<#>) z xs))::xs) (y::xs)
+
+spanslzSubtractiveExchange : spanslz ((y<->(monoidsum $ zipWith (<#>) z xs))::xs) (y::xs)
+-}
+
+{-
+Implication: Above can be rewritten in terms of (updateAt FZ).
+
+This characterization is combined with a natural theorem on bijection reorderings to show that for all indices (nel : Fin n), (updateAt nel (<->(monoidsum $ zipWith (<#>) z xs)) xs) `spanslz` xs.
+-}
+
+{-
+-- Not needed for our purposes.
+
+spanslzAdditiveExchange2 : spanslz xs ys -> spanslz ((zs<+>ys)++xs) (zs++xs)
+
+spanslzSubtractiveExchange2 : spanslz xs ys -> spanslz ((zs<->ys)++xs) (zs++xs)
+-}

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -27,7 +27,15 @@ multIdLeftNeutral : VerifiedRingWithUnity r => (a : Matrix _ _ r) -> Id <> a = a
 
 multIdRightNeutral : VerifiedRingWithUnity r => (a : Matrix _ _ r) -> a <> Id = a
 
--- rewriteMultInv : (VerifiedRingWithUnity r, VerifiedModule r a) -> (s : r) -> (x : a) -> (inverse s) <#> x = s <#> (inverse x)
+{-
+When checking type of ZZModuleSpan.rewriteMultInv:
+When checking an application of function Control.Algebra.VectorSpace.<#>:
+        Can't resolve type class Group r
+
+---
+
+rewriteMultInv : (VerifiedRingWithUnity r, VerifiedModule r a) -> (s : r) -> (x : a) -> (inverse s) <#> x = s <#> (inverse x)
+-}
 
 rewriteMultInvVect : VerifiedRingWithUnity r => (s : r) -> (x : Vect _ r) -> (inverse s) <#> x = s <#> (inverse x)
 

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -380,3 +380,16 @@ spanslztrans {na} {ni} {nu} {m} {xs} {ys} {zs} (vsx ** prvsx) (vsy ** prvsy) = (
 
 spanslzrefl : spanslz xs xs
 spanslzrefl = ( Id ** zippyScaleIdLeftNeutral _ )
+
+
+
+updateAtEquality : {ls : Matrix n k ZZ} -> {rs : Matrix k m ZZ} -> (updi : Fin n) -> (f : (i : Nat) -> Vect i ZZ -> Vect i ZZ) -> (updateAt updi (f k) ls) `zippyScale` rs = updateAt updi (f m) (ls `zippyScale` rs)
+updateAtEquality {ls=[]} updi f = FinZElim updi
+updateAtEquality {ls=l::ls} FZ f = ?updateAtEquality'
+updateAtEquality {ls=l::ls} (FS penupdi) f = vecHeadtailsEq Refl $ updateAtEquality penupdi f
+
+spanRowScalelz : (z : ZZ) -> (updi : Fin n') -> spanslz xs ys -> spanslz xs (updateAt updi (z<#>) ys)
+spanRowScalelz z updi (vs ** prvs) {xs} = (updateAt updi (z<#>) vs ** trans scaleMain $ rewrite sym prvs in Refl)
+	where
+		scaleMain : (updateAt updi (z<#>) vs) `zippyScale` xs = updateAt updi (z<#>) (vs `zippyScale` xs)
+		scaleMain = updateAtEquality updi ( \i => (z<#>) )

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -106,7 +106,16 @@ vectPermTo (MkIso to from toFrom fromTo) {n} {a} xs = map (((flip index) xs) . t
 
 moveUpdateAt : (sigma : Iso (Fin n) (Fin n)) -> vectPermTo sigma $ updateAt nel f xs = updateAt (runIso sigma nel) f (vectPermTo sigma xs)
 
+vecDeleteatpermEq : (sigma : Iso (Fin (S n)) (Fin (S n))) -> ( deleteAt (runIso sigma FZ) $ vectPermTo sigma xs = vectPermTo (weakenIsoByValFZ sigma) $ deleteAt FZ xs )
+vecDeleteatpermEq sigma@(MkIso to from toFrom fromTo) {xs} = ?vecDeleteatpermEq'
+
 deleteAtAsPermTail : (sigma : Iso (Fin (S n)) (Fin (S n))) -> ( xs = vectPermTo sigma (y::ys) ) -> ( deleteAt (runIso sigma FZ) xs = vectPermTo (weakenIsoByValFZ sigma) ys )
+deleteAtAsPermTail sigma@(MkIso to from toFrom fromTo) pr_xsRys {xs=xx::[]} {y} {ys=[]} = ?deleteAtAsPermTail_rhs_1
+	where
+		fin1elIsFZ : (el : Fin 1) -> el=FZ
+		fin1elIsFZ FZ = Refl
+		fin1elIsFZ (FS el) = FinZElim el
+deleteAtAsPermTail sigma@(MkIso to from toFrom fromTo) pr_xsRys {xs=xx::xxs} {y} {ys=yy::yys} = ?deleteAtAsPermTail_rhs_2
 
 multIdLeftNeutral : VerifiedRingWithUnity r => (a : Matrix _ _ r) -> Id <> a = a
 

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -26,6 +26,42 @@ multIdLeftNeutral : VerifiedRingWithUnity r => (a : Matrix _ _ r) -> Id <> a = a
 
 multIdRightNeutral : VerifiedRingWithUnity r => (a : Matrix _ _ r) -> a <> Id = a
 
+rewriteAssociativityUnderEquality : {f, g : a -> a -> a} -> ( (x : a) -> (y : a) -> f x y = g x y) -> (l `f` (c `f` r) = (l `f` c) `f` r) -> (l `g` (c `g` r) = (l `g` c) `g` r)
+rewriteAssociativityUnderEquality {f} {g} {l} {c} {r} fneq prf = trans (sym stepleft) $ trans prf stepright
+	where
+		stepleft : f l (f c r) = g l (g c r)
+		stepleft = rewrite sym (fneq c r) in fneq l _
+		stepright : f (f l c) r = g (g l c) r
+		stepright = rewrite sym (fneq l c) in fneq _ r
+
+{-
+-- Works both compiled and in the REPL
+
+rewriteAssociativityUnderEquality {f} {g} {l} {c} {r} fneq prf = ?rewriteAssociativityUnderEquality'
+
+rewriteAssociativityUnderEquality' = proof
+  intros
+  claim stepleft f l (f c r) = g l (g c r)
+  claim stepright f (f l c) r = g (g l c) r
+  unfocus
+  unfocus
+  exact trans (sym stepleft) $ trans prf stepright
+  exact rewrite sym (fneq l c) in fneq _ r
+  exact rewrite sym (fneq c r) in fneq l _
+
+-- Works in REPL but not compiled
+
+rewriteAssociativityUnderEquality {f} {g} {l} {c} {r} fneq prf = ?rewriteAssociativityUnderEquality'
+
+rewriteAssociativityUnderEquality' = proof
+  intros
+  exact trans _ $ trans prf _
+  exact trans _ (sym $ fneq l _)
+  exact trans (cong {f=(flip f) r} (fneq l c)) _
+  exact cong (sym $ fneq _ _)
+  exact fneq _ r
+-}
+
 
 
 {-
@@ -158,42 +194,6 @@ Same as above, but for lists of ZZ vectors specifically.
 -}
 
 
-
-rewriteAssociativityUnderEquality : {f, g : a -> a -> a} -> ( (x : a) -> (y : a) -> f x y = g x y) -> (l `f` (c `f` r) = (l `f` c) `f` r) -> (l `g` (c `g` r) = (l `g` c) `g` r)
-rewriteAssociativityUnderEquality {f} {g} {l} {c} {r} fneq prf = trans (sym stepleft) $ trans prf stepright
-	where
-		stepleft : f l (f c r) = g l (g c r)
-		stepleft = rewrite sym (fneq c r) in fneq l _
-		stepright : f (f l c) r = g (g l c) r
-		stepright = rewrite sym (fneq l c) in fneq _ r
-
-{-
--- Works both compiled and in the REPL
-
-rewriteAssociativityUnderEquality {f} {g} {l} {c} {r} fneq prf = ?rewriteAssociativityUnderEquality'
-
-rewriteAssociativityUnderEquality' = proof
-  intros
-  claim stepleft f l (f c r) = g l (g c r)
-  claim stepright f (f l c) r = g (g l c) r
-  unfocus
-  unfocus
-  exact trans (sym stepleft) $ trans prf stepright
-  exact rewrite sym (fneq l c) in fneq _ r
-  exact rewrite sym (fneq c r) in fneq l _
-
--- Works in REPL but not compiled
-
-rewriteAssociativityUnderEquality {f} {g} {l} {c} {r} fneq prf = ?rewriteAssociativityUnderEquality'
-
-rewriteAssociativityUnderEquality' = proof
-  intros
-  exact trans _ $ trans prf _
-  exact trans _ (sym $ fneq l _)
-  exact trans (cong {f=(flip f) r} (fneq l c)) _
-  exact cong (sym $ fneq _ _)
-  exact fneq _ r
--}
 
 zippyScale : Matrix n' n ZZ -> Matrix n w ZZ -> Matrix n' w ZZ
 zippyScale vs xs = map (\zs => monoidsum $ zipWith (<#>) zs xs) vs

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -160,6 +160,40 @@ Same as above, but for lists of ZZ vectors specifically.
 
 
 rewriteAssociativityUnderEquality : {f, g : a -> a -> a} -> ( (x : a) -> (y : a) -> f x y = g x y) -> (l `f` (c `f` r) = (l `f` c) `f` r) -> (l `g` (c `g` r) = (l `g` c) `g` r)
+rewriteAssociativityUnderEquality {f} {g} {l} {c} {r} fneq prf = trans (sym stepleft) $ trans prf stepright
+	where
+		stepleft : f l (f c r) = g l (g c r)
+		stepleft = rewrite sym (fneq c r) in fneq l _
+		stepright : f (f l c) r = g (g l c) r
+		stepright = rewrite sym (fneq l c) in fneq _ r
+
+{-
+-- Works both compiled and in the REPL
+
+rewriteAssociativityUnderEquality {f} {g} {l} {c} {r} fneq prf = ?rewriteAssociativityUnderEquality'
+
+rewriteAssociativityUnderEquality' = proof
+  intros
+  claim stepleft f l (f c r) = g l (g c r)
+  claim stepright f (f l c) r = g (g l c) r
+  unfocus
+  unfocus
+  exact trans (sym stepleft) $ trans prf stepright
+  exact rewrite sym (fneq l c) in fneq _ r
+  exact rewrite sym (fneq c r) in fneq l _
+
+-- Works in REPL but not compiled
+
+rewriteAssociativityUnderEquality {f} {g} {l} {c} {r} fneq prf = ?rewriteAssociativityUnderEquality'
+
+rewriteAssociativityUnderEquality' = proof
+  intros
+  exact trans _ $ trans prf _
+  exact trans _ (sym $ fneq l _)
+  exact trans (cong {f=(flip f) r} (fneq l c)) _
+  exact cong (sym $ fneq _ _)
+  exact fneq _ r
+-}
 
 zippyScale : Matrix n' n ZZ -> Matrix n w ZZ -> Matrix n' w ZZ
 zippyScale vs xs = map (\zs => monoidsum $ zipWith (<#>) zs xs) vs

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -9,6 +9,7 @@ import Data.Matrix.LinearCombinations
 
 import Data.ZZ
 import Control.Algebra.NumericInstances
+import Control.Algebra.ZZVerifiedInstances
 
 
 
@@ -93,40 +94,6 @@ Associative property for matrix multiplication
 -}
 
 timesMatMatIsAssociative : Ring a => {l : Matrix _ _ a} -> {c : Matrix _ _ a} -> {r : Matrix _ _ a} -> l <> (c <> r) = (l <> c) <> r
-
-
-
-{-
-ZZ is a VerifiedRing.
--}
-
-instance VerifiedSemigroup ZZ where
-	semigroupOpIsAssociative = ?semigroupOpIsAssociative_ZZ
-
-instance VerifiedMonoid ZZ where {
-	monoidNeutralIsNeutralL = ?monoidNeutralIsNeutralL_ZZ
-	monoidNeutralIsNeutralR = ?monoidNeutralIsNeutralR_ZZ
-}
-
-instance VerifiedGroup ZZ where {
-	groupInverseIsInverseL = ?groupInverseIsInverseL_ZZ
-	groupInverseIsInverseR = ?groupInverseIsInverseR_ZZ
-}
-
-instance VerifiedAbelianGroup ZZ where {
-	abelianGroupOpIsCommutative = ?abelianGroupOpIsCommutative_ZZ
-}
-
-instance VerifiedRing ZZ where {
-	ringOpIsAssociative = ?ringOpIsAssociative_ZZ
-	ringOpIsDistributiveL = ?ringOpIsDistributiveL_ZZ
-	ringOpIsDistributiveR = ?ringOpIsDistributiveR_ZZ
-}
-
-instance VerifiedRingWithUnity ZZ where {
-	ringWithUnityIsUnityL = ?ringWithUnityIsUnityL_ZZ
-	ringWithUnityIsUnityR = ?ringWithUnityIsUnityR_ZZ
-}
 
 
 

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -21,6 +21,10 @@ vecHeadtailsEq {x} {xs} {ys} headeq taileq = trans (vectConsCong x xs ys taileq)
 -- Also a solid proof:
 -- vecHeadtailsEq {x} {xs} {ys} headeq taileq = trans (cong {f=(::xs)} headeq) $ replace {P=\l => l::xs = l::ys} headeq $ vectConsCong x xs ys taileq
 
+multIdLeftNeutral : VerifiedRingWithUnity r => (a : Matrix _ _ r) -> Id <> a = a
+
+multIdRightNeutral : VerifiedRingWithUnity r => (a : Matrix _ _ r) -> a <> Id = a
+
 
 
 {-
@@ -96,6 +100,34 @@ timesMatMatIsAssociative : Ring a => {l : Matrix _ _ a} -> {c : Matrix _ _ a} ->
 ZZ is a VerifiedRing.
 -}
 
+instance VerifiedSemigroup ZZ where
+	semigroupOpIsAssociative = ?semigroupOpIsAssociative_ZZ
+
+instance VerifiedMonoid ZZ where {
+	monoidNeutralIsNeutralL = ?monoidNeutralIsNeutralL_ZZ
+	monoidNeutralIsNeutralR = ?monoidNeutralIsNeutralR_ZZ
+}
+
+instance VerifiedGroup ZZ where {
+	groupInverseIsInverseL = ?groupInverseIsInverseL_ZZ
+	groupInverseIsInverseR = ?groupInverseIsInverseR_ZZ
+}
+
+instance VerifiedAbelianGroup ZZ where {
+	abelianGroupOpIsCommutative = ?abelianGroupOpIsCommutative_ZZ
+}
+
+instance VerifiedRing ZZ where {
+	ringOpIsAssociative = ?ringOpIsAssociative_ZZ
+	ringOpIsDistributiveL = ?ringOpIsDistributiveL_ZZ
+	ringOpIsDistributiveR = ?ringOpIsDistributiveR_ZZ
+}
+
+instance VerifiedRingWithUnity ZZ where {
+	ringWithUnityIsUnityL = ?ringWithUnityIsUnityL_ZZ
+	ringWithUnityIsUnityR = ?ringWithUnityIsUnityR_ZZ
+}
+
 
 
 {-
@@ -165,7 +197,7 @@ rewriteAssociativityUnderEquality : {f, g : a -> a -> a} -> ( (x : a) -> (y : a)
 zippyScale : Matrix n' n ZZ -> Matrix n w ZZ -> Matrix n' w ZZ
 zippyScale vs xs = map (\zs => monoidsum $ zipWith (<#>) zs xs) vs
 
--- Inherited property from (<>) equality proven in Data.Matrix.LinearCombinations
+-- Inherited properties from (<>) equality proven in Data.Matrix.LinearCombinations
 zippyScaleIsAssociative : l `zippyScale` (c `zippyScale` r) = (l `zippyScale` c) `zippyScale` r
 {-
 zippyScaleIsAssociative = ?zippyScaleIsAssociative'
@@ -174,6 +206,12 @@ zippyScaleIsAssociative = ?zippyScaleIsAssociative'
 zippyScaleIsAssociative_squaremats : {l, c, r : Matrix n n ZZ} -> l `zippyScale` (c `zippyScale` r) = (l `zippyScale` c) `zippyScale` r
 -- zippyScaleIsAssociative_squaremats = ?zippyScaleIsAssociative_squaremats'
 zippyScaleIsAssociative_squaremats {l} {c} {r} {n} = ( rewriteAssociativityUnderEquality {l=l} {c=c} {r=r} {f=(<>)} {g=\varg => \xarg => map (\zs => monoidsum (zipWith (<#>) zs xarg)) varg} (timesMatMatAsMultipleLinearCombos {n'=n} {n=n} {w=n}) ) $ timesMatMatIsAssociative {l=l} {c=c} {r=r}
+
+zippyScaleIdLeftNeutral : (a : Matrix n m ZZ) -> Id `zippyScale` a = a
+zippyScaleIdLeftNeutral _ = trans (sym $ timesMatMatAsMultipleLinearCombos _ _) $ multIdLeftNeutral _
+
+zippyScaleIdRightNeutral : (a : Matrix _ _ ZZ) -> a `zippyScale` Id = a
+zippyScaleIdRightNeutral _ = trans (sym $ timesMatMatAsMultipleLinearCombos _ _) $ multIdRightNeutral _
 
 {-
 
@@ -336,3 +374,8 @@ spanslztrans {na} {ni} {nu} {m} {xs} {ys} {zs} (vsx ** prvsx) (vsy ** prvsy) = (
 		spanslztrans_matrix = vsy <> vsx
 		spanslztrans_linearcombprop : spanslztrans_matrix `zippyScale` xs = zs
 		spanslztrans_linearcombprop = trans (cong {f=(flip zippyScale) xs} $ timesMatMatAsMultipleLinearCombos vsy vsx) $ trans (sym $ zippyScaleIsAssociative {l=vsy} {c=vsx} {r=xs}) $ trans (cong {f=zippyScale vsy} prvsx) prvsy
+
+
+
+spanslzrefl : spanslz xs xs
+spanslzrefl = ( Id ** zippyScaleIdLeftNeutral _ )

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -47,8 +47,12 @@ weakenIsoByValFZ {n} (MkIso to from toFrom fromTo) = MkIso to' from' toFrom' fro
 		to' : Fin n -> Fin n
 		to' nel = runIso eitherBotRight $ (map ((permDoesntFix_corrolary (MkIso to from toFrom fromTo) (FS nel) (FZNotFS . sym)) . sym) (finReduce $ to $ FS nel)) <*> (map sym $ finReduce $ to FZ)
 		from' : Fin n -> Fin n
+		from' = ?weakenIsoByValFZ_from_pr
 		toFrom' : (y : Fin n) -> to' (from' y) = y
+		-- Suggestion: with (to $ FS nel) or perhaps by injectivity of FS.
+		toFrom' = ?weakenIsoByValFZ_toFrom_pr
 		fromTo' : (x : Fin n) -> from' (to' x) = x
+		fromTo' = ?weakenIsoByValFZ_fromTo_pr
 
 -- fromEither {a=Fin n} : Either (Fin n) (Fin n) -> Fin n
 -- goal : (finReduce $ to $ FS nel : Either (Fin n) (FZ = to $ FS nel)) -> Either (Fin n) (Fin n)


### PR DESCRIPTION
Add many properties of span. Top-down development - goal is to create all the lemmas necessary to get the main operation of Gaussian elimination,

`spanslzAdditiveExchangeAt : (nel : Fin (S predn)) -> spanslz (updateAt nel (<+>(z<\>(deleteRow nel xs))) xs) xs`

as a modification of

`spanslzAdditiveExchange : spanslz ((y<+>(z<\>xs))::xs) (y::xs)`.

As such, there are dozens of holes created in this phase of the project. Nonetheless, plenty of them are for known algebraic identities, like that `ZZ` is a ring (called a `VerifiedRingWithUnity` in Idris terms), and their remaining unproved does not really reflect on the obligations of the project.

Note that the type of `gaussElimlz` has changed to require the input and output matrices span eachother rather than a one-sided relation.
