### PR TITLE
Gauss related arguments

### DIFF
--- a/Data/Matrix/AlgebraicVerified.idr
+++ b/Data/Matrix/AlgebraicVerified.idr
@@ -91,3 +91,41 @@ instance (VerifiedRingWithUnity a) => VerifiedModule a (Matrix n m a) where {
 	moduleScalarMultDistributiveWRTVectorAddition = ?moduleScalarMultDistributiveWRTVectorAddition_Mat
 	moduleScalarMultDistributiveWRTModuleAddition = ?moduleScalarMultDistributiveWRTModuleAddition_Mat
 }
+
+
+
+{-
+Trivial identities about (unital) rings.
+-}
+
+
+
+ringNegationCommutesWithLeftMult : VerifiedRing a => (left, right : a) -> left<.>(inverse right) = inverse $ left<.>right
+
+ringNegationCommutesWithRightMult : VerifiedRing a => (left, right : a) -> (inverse left)<.>right = inverse $ left<.>right
+
+-- The addition-as-quasigroup proof where (0.x = 0.x + 0.x) is potentially shorter.
+ringNeutralIsMultZeroL : VerifiedRing a => (x : a) -> Algebra.neutral <.> x = Algebra.neutral
+{-
+ringNeutralIsMultZeroL x = neutral<.>x = (x <+> inverse x)<.>x = (x<.>x)<+>((inverse x)<.>x) = (x<.>x)<+>(inverse $ x<.>x) = neutral
+-}
+{-
+ringNeutralIsMultZeroL x =
+	Algebra.neutral<.>x	={ cong {f=(<.>x)} $ sym $ groupInverseIsInverseL x }=
+	(x <+> inverse x)<.>x	={ ringOpIsDistributiveR x (inverse x) x }=
+	(x<.>x)<+>((inverse x)<.>x) ={ cong {f=((x<.>x)<+>)} $ ringNegationCommutesWithRightMult x x }=
+	(x<.>x)<+>(inverse $ x<.>x) ={ groupInverseIsInverseL (x<.>x) }=
+	Algebra.neutral	QED
+-}
+ringNeutralIsMultZeroL x =
+	trans ( cong {f=(<.>x)} $ sym $ groupInverseIsInverseL x ) $
+	trans ( ringOpIsDistributiveR x (inverse x) x ) $
+	trans ( cong {f=((x<.>x)<+>)} $ ringNegationCommutesWithRightMult x x ) $
+	groupInverseIsInverseL (x<.>x)
+
+ringNeutralIsMultZeroR : VerifiedRing a => (x : a) -> x <.> Algebra.neutral = Algebra.neutral
+ringNeutralIsMultZeroR x =
+	trans ( cong {f=(x<.>)} $ sym $ groupInverseIsInverseL x ) $
+	trans ( ringOpIsDistributiveL x x (inverse x) ) $
+	trans ( cong {f=((x<.>x)<+>)} $ ringNegationCommutesWithLeftMult x x ) $
+	groupInverseIsInverseL (x<.>x)

--- a/Data/Matrix/LinearCombinations.idr
+++ b/Data/Matrix/LinearCombinations.idr
@@ -6,6 +6,9 @@ import Classes.Verified -- definition of verified algebras other than modules
 import Data.Matrix
 import Data.Matrix.Algebraic -- module instances; from Idris 0.9.20
 
+import Data.Vect.Structural
+import Data.Matrix.Structural
+
 import Data.ZZ
 
 
@@ -58,46 +61,6 @@ etaBinary f = trans (eta f) $ trans baz1 $ trans bar baz2
 		baz1 = sym flipIsInvolutionExtensional
 		baz2 : flip ( flip (\c => \d => f c d) ) = (\c => \d => f c d)
 		baz2 = flipIsInvolutionExtensional
-
-
-
-total
-zeroVecEq : {a : Vect 0 r} -> {b : Vect 0 r} -> a = b
-zeroVecEq {a=[]} {b=[]} = Refl
-
-
-
-total
-vecSingletonReplicateEq : ((u : a) -> v=u) -> (xs : Vect n a) -> (xs = replicate n v)
-vecSingletonReplicateEq f [] = Refl
-vecSingletonReplicateEq f (x::xs) {v} = rewrite sym (f x) in cong {f=(v::)} (vecSingletonReplicateEq f xs)
-
-
-
-total
-zeroVecVecId : (xs : Vect n (Vect 0 a)) -> (xs = replicate n [])
-zeroVecVecId = vecSingletonReplicateEq (\b => zeroVecEq {a=[]} {b=b})
-
-
-
-total
-headMapChariz : {xs : Vect (S n) _} -> head $ map f xs = f $ head xs
-headMapChariz {xs=x::xs} = Refl
-
-mapheadrec : with Data.Vect ( map head (v::vs) = (head v) :: (map head vs) )
-mapheadrec = Refl
-
-headtails : (v : Vect (S predk) _) -> v = (head v) :: (tail v)
-headtails (vv::vvs) = Refl
-
-
-
--- The theorem below this one should not be a necessary weakening, since the functions have equivalent definitions.
--- indexFZIshead : index FZ = Data.Vect.head
-
-total
-indexFZIsheadValued : index FZ xs = head xs
-indexFZIsheadValued {xs=x :: xs} = Refl
 
 
 
@@ -310,14 +273,6 @@ lem3_lemma_1 = proof
 	intro
 	compute
 	exact id
-
-
-
-transposeNHead: with Data.Vect ( head $ transpose xs = map head xs )
-
-transposeNTail : with Data.Vect ( transpose $ tail $ transpose xs = map tail xs )
-
-transposeIsInvolution : with Data.Vect ( transpose $ transpose xs = xs )
 
 
 

--- a/Data/Matrix/Structural.idr
+++ b/Data/Matrix/Structural.idr
@@ -14,6 +14,8 @@ import Data.Vect.Structural
 
 transposeNHead: with Data.Vect ( head $ transpose xs = map head xs )
 
+tranposeIndexChariz : index k $ transpose xs = getCol k xs
+
 transposeNTail : with Data.Vect ( transpose $ tail $ transpose xs = map tail xs )
 
 transposeIsInvolution : with Data.Vect ( transpose $ transpose xs = xs )
@@ -25,3 +27,8 @@ vecMatMultIsTransposeVecMult v xs = Refl
 
 matVecMultIsVecTransposeMult : Ring a => (v : Vect m a) -> (xs : Matrix n m a) -> xs </> v = v <\> (transpose xs)
 matVecMultIsVecTransposeMult v xs = sym $ trans (vecMatMultIsTransposeVecMult v $ transpose xs) $ cong {f=(</> v)} $ transposeIsInvolution {xs=xs}
+
+headVecMatMultChariz : Ring a => {xs : Matrix _ (S _) a} -> head $ v<\>xs = v <:> (getCol FZ xs)
+headVecMatMultChariz {v} {xs} = trans (sym $ indexFZIsheadValued {xs=v<\>xs})
+	$ trans (indexMapChariz {k=FZ} {f=(v<:>)} {xs=transpose xs})
+	$ cong {f=(v<:>)} $ tranposeIndexChariz {k=FZ} {xs=xs}

--- a/Data/Matrix/Structural.idr
+++ b/Data/Matrix/Structural.idr
@@ -1,0 +1,27 @@
+module Data.Matrix.Structural
+
+-- For structural lemmas involving matrix operations
+import Control.Algebra
+import Control.Algebra.VectorSpace -- definition of module
+import Classes.Verified -- definition of verified algebras other than modules
+import Data.Matrix
+import Data.Matrix.Algebraic -- module instances; from Idris 0.9.20
+import Data.Matrix.AlgebraicVerified
+
+import Data.Vect.Structural
+
+
+
+transposeNHead: with Data.Vect ( head $ transpose xs = map head xs )
+
+transposeNTail : with Data.Vect ( transpose $ tail $ transpose xs = map tail xs )
+
+transposeIsInvolution : with Data.Vect ( transpose $ transpose xs = xs )
+
+
+
+vecMatMultIsTransposeVecMult : Ring a => (v : Vect n a) -> (xs : Matrix n m a) -> v <\> xs = (transpose xs) </> v
+vecMatMultIsTransposeVecMult v xs = Refl
+
+matVecMultIsVecTransposeMult : Ring a => (v : Vect m a) -> (xs : Matrix n m a) -> xs </> v = v <\> (transpose xs)
+matVecMultIsVecTransposeMult v xs = sym $ trans (vecMatMultIsTransposeVecMult v $ transpose xs) $ cong {f=(</> v)} $ transposeIsInvolution {xs=xs}

--- a/Data/Matrix/ZZVerified.idr
+++ b/Data/Matrix/ZZVerified.idr
@@ -1,0 +1,70 @@
+module Data.Matrix.ZZVerified
+
+import Control.Algebra
+import Control.Algebra.VectorSpace -- definition of module
+import Classes.Verified -- definition of verified algebras other than modules
+import Data.Matrix
+import Data.Matrix.Algebraic -- module instances; from Idris 0.9.20
+import Data.Matrix.AlgebraicVerified
+
+import Data.Vect.Structural
+import Data.Matrix.Structural
+
+import Data.ZZ
+import Control.Algebra.ZZVerifiedInstances
+
+-- import Data.Matrix.LinearCombinations ( timesVectMatAsHeadTail_ByTransposeElimination )
+import Data.Matrix.LinearCombinations
+
+
+
+{-
+Identities whose proof is particular to ZZ.
+-}
+
+
+
+{-
+-- More instance collisions prevent a proof. (<:>) invokes a (neutral) for the ring which differs from (the a Algebra.neutral).
+
+ringVecNeutralIsVecPtwiseProdZeroL : VerifiedRing a => (xs : Vect n a) -> xs <:> (the (Vect n a) Algebra.neutral) = the a Algebra.neutral
+ringVecNeutralIsVecPtwiseProdZeroL [] {a} = Refl
+ringVecNeutralIsVecPtwiseProdZeroL (x::xs) = vecHeadtailsEq (ringNeutralIsMultZeroL x) $ ringVecNeutralIsVecPtwiseProdZeroL xs
+
+ringVecNeutralIsVecPtwiseProdZeroR : VerifiedRing a => (xs : Vect n a) -> (the (Vect n a) Algebra.neutral) <:> xs = the a Algebra.neutral
+ringVecNeutralIsVecPtwiseProdZeroR [] {a} = Refl
+ringVecNeutralIsVecPtwiseProdZeroR (x::xs) = vecHeadtailsEq (ringNeutralIsMultZeroR x) $ ringVecNeutralIsVecPtwiseProdZeroR xs
+
+matVecMultIsVecTransposeMult : Ring a => (v : Vect n a) -> (xs : Matrix n m a) -> v <\> xs = (transpose xs) </> v
+
+ringVecNeutralIsMatVecMultZero : VerifiedRing a => (xs : Matrix n m a) -> xs </> Algebra.neutral = Algebra.neutral
+ringVecNeutralIsMatVecMultZero [] = Refl
+ringVecNeutralIsMatVecMultZero (x::xs) = vecHeadtailsEq (ringVecNeutralIsVecPtwiseProdZeroR x) $ ringVecNeutralIsMatVecMultZero xs
+
+ringVecNeutralIsVecMatMultZero : VerifiedRing a => (xs : Matrix n m a) -> Algebra.neutral <\> xs = Algebra.neutral
+ringVecNeutralIsVecMatMultZero xs = trans (vecMatMultTransposeEq Algebra.neutral xs) $ ringVecNeutralIsMatVecMultZero $ transpose xs
+-}
+
+zzVecNeutralIsVecPtwiseProdZeroL : (xs : Vect n ZZ) -> xs <:> Algebra.neutral = Algebra.neutral
+zzVecNeutralIsVecPtwiseProdZeroL [] = Refl
+-- zzVecNeutralIsVecPtwiseProdZeroL (x::xs) = vecHeadtailsEq (ringNeutralIsMultZeroR x) $ zzVecNeutralIsVecPtwiseProdZeroL xs
+
+zzVecNeutralIsVecPtwiseProdZeroR : (xs : Vect n ZZ) -> Algebra.neutral <:> xs = Algebra.neutral
+zzVecNeutralIsVecPtwiseProdZeroR [] = Refl
+-- zzVecNeutralIsVecPtwiseProdZeroR (x::xs) = vecHeadtailsEq (ringNeutralIsMultZeroL x) $ zzVecNeutralIsVecPtwiseProdZeroR xs
+
+zzVecNeutralIsVecMatMultZero : (xs : Matrix n m ZZ) -> Algebra.neutral <\> xs = Algebra.neutral
+zzVecNeutralIsVecMatMultZero xs {m=Z} = zeroVecEq
+zzVecNeutralIsVecMatMultZero xs {m=S predm} = trans timesVectMatAsHeadTail_ByTransposeElimination $ vecHeadtailsEq (zzVecNeutralIsVecPtwiseProdZeroR $ map Vect.head xs) $ zzVecNeutralIsVecMatMultZero $ map Vect.tail xs
+
+zzVecNeutralIsMatVecMultZero : (xs : Matrix n m ZZ) -> xs </> Algebra.neutral = Algebra.neutral
+zzVecNeutralIsMatVecMultZero xs = trans (matVecMultIsVecTransposeMult Algebra.neutral xs) $ zzVecNeutralIsVecMatMultZero (transpose xs)
+
+zzVecNeutralIsNeutralL : (l : Vect n ZZ) -> l<+>Algebra.neutral=l
+-- zzVecNeutralIsNeutralL = monoidNeutralIsNeutralL
+
+zzVecNeutralIsNeutralR : (r : Vect n ZZ) -> Algebra.neutral<+>r=r
+-- zzVecNeutralIsNeutralR = monoidNeutralIsNeutralR
+
+zzVecScalarUnityIsUnity : (v : Vect n ZZ) -> (Algebra.unity {a=ZZ}) <#> v = v
+-- zzVecScalarUnityIsUnity = moduleScalarUnityIsUnity

--- a/Data/Vect/Structural.idr
+++ b/Data/Vect/Structural.idr
@@ -8,6 +8,69 @@ import Data.Matrix
 import Data.Matrix.Algebraic -- module instances; from Idris 0.9.20
 import Data.Matrix.AlgebraicVerified
 
+
+
+{-
+Theorem (vecHeadtailsEq) for proving equality of (Vect)s by proving equality of their heads and tails. Often used after (headtails).
+-}
+
+
+
+vecHeadtailsEq : {xs,ys : Vect _ _} -> ( headeq : x = y ) -> ( taileq : xs = ys ) -> x::xs = y::ys
+vecHeadtailsEq {x} {xs} {ys} headeq taileq = trans (vectConsCong x xs ys taileq) $ cong {f=(::ys)} headeq
+-- Also a solid proof:
+-- vecHeadtailsEq {x} {xs} {ys} headeq taileq = trans (cong {f=(::xs)} headeq) $ replace {P=\l => l::xs = l::ys} headeq $ vectConsCong x xs ys taileq
+
+
+
+{-
+* Theorems characterizing (Vect)s of degenerate qualities.
+* Theorems characterizing the index or head of a list created with a certain operation.
+* The theorem (weakenedInd) about comparing an index of a list to an index of its (init).
+-}
+
+
+
+total
+zeroVecEq : {a : Vect 0 r} -> {b : Vect 0 r} -> a = b
+zeroVecEq {a=[]} {b=[]} = Refl
+
+
+
+total
+vecSingletonReplicateEq : ((u : a) -> v=u) -> (xs : Vect n a) -> (xs = replicate n v)
+vecSingletonReplicateEq f [] = Refl
+vecSingletonReplicateEq f (x::xs) {v} = rewrite sym (f x) in cong {f=(v::)} (vecSingletonReplicateEq f xs)
+
+
+
+total
+zeroVecVecId : (xs : Vect n (Vect 0 a)) -> (xs = replicate n [])
+zeroVecVecId = vecSingletonReplicateEq (\b => zeroVecEq {a=[]} {b=b})
+
+
+
+total
+headMapChariz : {xs : Vect (S n) _} -> head $ map f xs = f $ head xs
+headMapChariz {xs=x::xs} = Refl
+
+mapheadrec : with Data.Vect ( map head (v::vs) = (head v) :: (map head vs) )
+mapheadrec = Refl
+
+headtails : (v : Vect (S predk) _) -> v = (head v) :: (tail v)
+headtails (vv::vvs) = Refl
+
+
+
+-- The theorem below this one should not be a necessary weakening, since the functions have equivalent definitions.
+-- indexFZIshead : index FZ = Data.Vect.head
+
+total
+indexFZIsheadValued : index FZ xs = head xs
+indexFZIsheadValued {xs=x :: xs} = Refl
+
+
+
 indexMapChariz : Data.Vect.index k $ map f xs = f $ index k xs
 indexMapChariz {xs=[]} {k} = FinZElim k
 -- indexMapChariz {xs} {f} {k=FZ} = trans indexFZIsheadValued $ trans headMapChariz $ sym $ cong indexFZIsheadValued
@@ -29,6 +92,63 @@ updateAtSuccRowVanishesUnderHead : head $ updateAt (FS k) f xs = head xs
 updateAtSuccRowVanishesUnderHead {xs=x::xs} = Refl
 
 zipWithEntryChariz : index i $ Vect.zipWith m x y = m (index i x) (index i y)
+
+
+
+plusOneVectIsSuccVect : Vect (n+1) a = Vect (S n) a
+plusOneVectIsSuccVect {a} {n} = sym $ cong {f=\k => Vect k a} $ trans (cong {f=S} $ sym $ plusZeroRightNeutral n) $ plusSuccRightSucc n Z
+
+appendedSingletonAsSuccVect : (xs : Vect n a) -> (v : a) -> Vect (S n) a
+appendedSingletonAsSuccVect {a} {n} xs v = rewrite sym $ plusOneVectIsSuccVect {a=a} {n=n} in (xs++[v])
+
+consAppendedSingleton : {xs : Vect n a} -> appendedSingletonAsSuccVect (x::xs) v = x::appendedSingletonAsSuccVect xs v
+consAppendedSingleton {x} {xs} {v} {a} {n} = the ( appendedSingletonAsSuccVect (x::xs) v = x::appendedSingletonAsSuccVect xs v ) ?consAppendedSingleton_rhs
+
+{-
+-- Too many problems with this, rewriting the types to handle Nat addition.
+lastInd : {xs : Vect n a} -> Data.Vect.index Data.Fin.last (rewrite sym $ plusOneVectIsSuccVect {a=a} {n=n} in (xs++[v])) = v
+-}
+
+-- Could this be done with the reversal isomorphism of each Fin?
+lastInd : {xs : Vect n a} -> index Data.Fin.last $ appendedSingletonAsSuccVect xs v = v
+lastInd {xs=[]} = Refl
+lastInd {xs=x::xs} {v} = rewrite consAppendedSingleton {x=x} {xs=xs} {v=v} in (lastInd {xs=xs} {v=v})
+{-
+
+"ERROR ON INTROS" BUG, CASE, SOLUTION
+
+--------
+
+> lastInd {xs=x::xs} = ?lastInd_rhs_2
+
+> :prove lastInd_rhs_2
+lastInd_rhs_2> intro
+
+Type mismatch between
+        Vect k a = Vect k a
+and
+        Vect (S (S k)) a = Vect (S (plus k 1)) a
+
+which I think means the type signature for (lastInd) is being reanalyzed in the presence of (x::xs), as if inlined, in such a way that the sucessor to rewrite is the one inside rather than outside, or something.
+
+This works fine:
+
+> lastInd {xs=x::xs} {v} = the ( (index Data.Fin.last $ appendedSingletonAsSuccVect (x::xs) v) = v ) ?lastInd_rhs_2
+
+and spells out
+
+> lastInd {xs=x::xs} {v} = the ( (index Data.Fin.last $ appendedSingletonAsSuccVect (x::xs) v) = v ) ( rewrite consAppendedSingleton {x=x} {xs=xs} {v=v} in lastInd {xs=xs} {v=v} )
+
+-}
+
+{-
+Could this be done with the reversal isomorphism of each Fin and a proof that weaken becomes FS under it?
+-}
+total
+weakenedInd : {xs : Vect n a} -> index (weaken k) $ appendedSingletonAsSuccVect xs v = index k xs
+weakenedInd {xs=[]} {k} = absurd k
+weakenedInd {xs=x::xs} {k=FZ} {v} = rewrite consAppendedSingleton {x=x} {xs=xs} {v=v} in Refl
+weakenedInd {xs=x::xs} {k=FS j} {v} = rewrite consAppendedSingleton {x=x} {xs=xs} {v=v} in weakenedInd {xs=xs} {k=j} {v}
 
 
 

--- a/Data/Vect/Structural.idr
+++ b/Data/Vect/Structural.idr
@@ -98,26 +98,34 @@ zipWithEntryChariz : index i $ Vect.zipWith m x y = m (index i x) (index i y)
 plusOneVectIsSuccVect : Vect (n+1) a = Vect (S n) a
 plusOneVectIsSuccVect {a} {n} = sym $ cong {f=\k => Vect k a} $ trans (cong {f=S} $ sym $ plusZeroRightNeutral n) $ plusSuccRightSucc n Z
 
+{-
 appendedSingletonAsSuccVect : (xs : Vect n a) -> (v : a) -> Vect (S n) a
 appendedSingletonAsSuccVect {a} {n} xs v = rewrite sym $ plusOneVectIsSuccVect {a=a} {n=n} in (xs++[v])
+-}
+appendedSingletonAsSuccVect : (xs : Vect n a) -> (v : a) -> Vect (S n) a
+appendedSingletonAsSuccVect [] v = [v]
+appendedSingletonAsSuccVect (x::xs) v = x::appendedSingletonAsSuccVect xs v
 
+-- With the old implementation of (appendedSingletonAsSuccVect) this seemed impossible to prove.
 consAppendedSingleton : {xs : Vect n a} -> appendedSingletonAsSuccVect (x::xs) v = x::appendedSingletonAsSuccVect xs v
-consAppendedSingleton {x} {xs} {v} {a} {n} = the ( appendedSingletonAsSuccVect (x::xs) v = x::appendedSingletonAsSuccVect xs v ) ?consAppendedSingleton_rhs
+consAppendedSingleton {x} {xs} {v} {a} {n} = Refl
 
 {-
 -- Too many problems with this, rewriting the types to handle Nat addition.
 lastInd : {xs : Vect n a} -> Data.Vect.index Data.Fin.last (rewrite sym $ plusOneVectIsSuccVect {a=a} {n=n} in (xs++[v])) = v
 -}
 
--- Could this be done with the reversal isomorphism of each Fin?
+{-
+-- Stopped typechecking once the implementation of (appendedSingletonAsSuccVect) changed.
 lastInd : {xs : Vect n a} -> index Data.Fin.last $ appendedSingletonAsSuccVect xs v = v
 lastInd {xs=[]} = Refl
 lastInd {xs=x::xs} {v} = rewrite consAppendedSingleton {x=x} {xs=xs} {v=v} in (lastInd {xs=xs} {v=v})
-{-
+
+-----
 
 "ERROR ON INTROS" BUG, CASE, SOLUTION
 
---------
+---
 
 > lastInd {xs=x::xs} = ?lastInd_rhs_2
 
@@ -141,14 +149,28 @@ and spells out
 
 -}
 
+-- Could this be done with the reversal isomorphism of each Fin?
+lastInd : {xs : Vect n a} -> index Data.Fin.last $ appendedSingletonAsSuccVect xs v = v
+lastInd {xs=[]} = Refl
+lastInd {xs=x::xs} {v} = lastInd {xs=xs} {v=v}
+
+{-
+-- Stopped typechecking once the implementation of (appendedSingletonAsSuccVect) changed.
+total
+weakenedInd : {xs : Vect n a} -> index (weaken k) $ appendedSingletonAsSuccVect xs v = index k xs
+weakenedInd {xs=[]} {k} = absurd k
+weakenedInd {xs=x::xs} {k=FZ} {v} = rewrite consAppendedSingleton {x=x} {xs=xs} {v=v} in Refl
+weakenedInd {xs=x::xs} {k=FS j} {v} = rewrite consAppendedSingleton {x=x} {xs=xs} {v=v} in weakenedInd {xs=xs} {k=j} {v}
+-}
+
 {-
 Could this be done with the reversal isomorphism of each Fin and a proof that weaken becomes FS under it?
 -}
 total
 weakenedInd : {xs : Vect n a} -> index (weaken k) $ appendedSingletonAsSuccVect xs v = index k xs
 weakenedInd {xs=[]} {k} = absurd k
-weakenedInd {xs=x::xs} {k=FZ} {v} = rewrite consAppendedSingleton {x=x} {xs=xs} {v=v} in Refl
-weakenedInd {xs=x::xs} {k=FS j} {v} = rewrite consAppendedSingleton {x=x} {xs=xs} {v=v} in weakenedInd {xs=xs} {k=j} {v}
+weakenedInd {xs=x::xs} {k=FZ} {v} = Refl
+weakenedInd {xs=x::xs} {k=FS j} {v} = weakenedInd {xs=xs} {k=j} {v}
 
 
 

--- a/Data/Vect/Structural.idr
+++ b/Data/Vect/Structural.idr
@@ -1,0 +1,61 @@
+module Data.Vect.Structural
+
+-- For structural lemmas about (Vect) modules
+import Control.Algebra
+import Control.Algebra.VectorSpace -- definition of module
+import Classes.Verified -- definition of verified algebras other than modules
+import Data.Matrix
+import Data.Matrix.Algebraic -- module instances; from Idris 0.9.20
+import Data.Matrix.AlgebraicVerified
+
+indexMapChariz : Data.Vect.index k $ map f xs = f $ index k xs
+indexMapChariz {xs=[]} {k} = FinZElim k
+-- indexMapChariz {xs} {f} {k=FZ} = trans indexFZIsheadValued $ trans headMapChariz $ sym $ cong indexFZIsheadValued
+indexMapChariz {xs=x::xs} {f} {k=FZ} = Refl
+indexMapChariz {xs=x::xs} {f} {k=FS k} = indexMapChariz {xs=xs} {f=f} {k=k}
+
+indexUpdateAtChariz : index i $ updateAt i f xs = f $ index i xs
+indexUpdateAtChariz {xs=[]} {i} = FinZElim i
+indexUpdateAtChariz {xs=(x::xs)} {f} {i=FZ} = Refl
+indexUpdateAtChariz {xs=x::xs} {f} {i=FS i} = indexUpdateAtChariz {xs=xs} {f=f} {i=i}
+
+updateAtIndIsMapAtInd : index i $ updateAt i f xs = index i $ map f xs
+updateAtIndIsMapAtInd = trans indexUpdateAtChariz $ sym indexMapChariz
+
+deleteSuccRowVanishesUnderHead : head $ deleteRow (FS k) xs = head xs
+deleteSuccRowVanishesUnderHead {xs=x::xs} = Refl
+
+updateAtSuccRowVanishesUnderHead : head $ updateAt (FS k) f xs = head xs
+updateAtSuccRowVanishesUnderHead {xs=x::xs} = Refl
+
+zipWithEntryChariz : index i $ Vect.zipWith m x y = m (index i x) (index i y)
+
+
+
+{-
+Theorems about the module (Vect n a) over a ring (a):
+* Compatibility between the operations of the ring (a) and of (Vect n a) as a module under (index).
+-}
+
+
+
+-- For completeness's sake, these should have (index FZ) as (head) forms proved.
+
+indexCompatInverse : VerifiedRingWithUnity a => (xs : Vect n a) -> (i : Fin n) -> index i $ inverse xs = inverse $ index i xs
+
+indexCompatAdd : VerifiedRingWithUnity a => (xs, ys : Vect n a) -> (i : Fin n) -> index i $ xs <+> ys = index i xs <+> index i ys
+indexCompatAdd xs ys i = zipWithEntryChariz {x=xs} {y=ys} {i=i} {m=(<+>)}
+
+{-
+Proof obstruction seems to be that the meaning of "inverse" depends on whether the class hierarchy is treated as
+
+	VerifiedGroup < Group < Monoid < Semigroup
+
+or as
+
+	VerifiedGroup < VerifiedMonoid < VerifiedSemigroup < Semigroup
+-}
+indexCompatSub : VerifiedRingWithUnity a => (xs, ys : Vect n a) -> (i : Fin n) -> index i $ xs <-> ys = index i xs <-> index i ys
+indexCompatSub xs ys i ?= trans (indexCompatAdd xs (inverse ys) i) $ cong {f=((index i xs)<+>)} $ indexCompatInverse ys i
+
+indexCompatScaling : VerifiedRingWithUnity a => (r : a) -> (xs : Vect n a) -> (i : Fin n) -> index i $ r <#> xs = r <.> index i xs

--- a/FinOrdering.idr
+++ b/FinOrdering.idr
@@ -73,3 +73,5 @@ instance DecLTE Nat where
 instance DecLT (Fin n) where
 	decLT {n} = decLTFin n
 -}
+
+lteToLTERel : {a, b : Nat} -> LTE a b -> LTERel a b

--- a/ImplicitArgsError.idr
+++ b/ImplicitArgsError.idr
@@ -1,0 +1,223 @@
+module ImplicitArgsError
+
+import Data.Vect
+
+{-
+Expected behavior here - Idris throws an error
+
+> implTy : Type -> Type
+> implTy ty = Vect n ty -> Nat
+
+"
+When checking right hand side of implTy with expected type
+        Type
+
+When checking an application of type constructor Data.Vect.Vect:
+        No such variable n
+"
+-}
+
+-- This creates a problem down the line
+implTy : Type -> Type
+implTy ty = {n : Nat} -> Vect n ty -> Nat
+
+-- This seems fine
+fn : (ty : Type) -> (offender : implTy ty) -> Nat
+fn ty offender = foo
+	where
+		barA : Vect 5 ()	
+		barB : implTy ty
+		foo : Nat
+
+{-
+-- However, this one is a problem
+fn2 : (ty : Type) -> (offender : implTy ty) -> Nat
+fn2 ty offender = foo
+	where
+		barA : Type	
+		barB : implTy barA
+		foo : Nat
+-}
+
+-- Similar problem here, with implTy2 and fn3
+implTy2 : Vect n () -> Type
+implTy2 v {n} = {m : Nat} -> Vect m (Vect n ()) -> Nat
+
+{-
+fn3 : (xs : Vect n ()) -> (offender : implTy2 xs) -> Nat
+fn3 xs offender = foo
+	where
+		barA : Vect 5 ()	
+		barB : implTy2 barA
+		foo : Nat
+-}
+
+{-
+This seems okay, where there is no parameter to the type, because the problem occurs when (offender) interacts with another value of the type-valued function.
+-}
+implTy3 : Type
+implTy3 = {n : Nat} -> Vect n () -> Nat
+
+fn4 : (xs : Vect n ()) -> (offender : implTy3) -> Nat
+fn4 xs offender = foo
+	where
+		bar : implTy3
+		foo : Nat
+
+{-
+Namespace refinement doesn't help
+
+---
+
+fn5 : (xs : Vect n ()) -> (offender : ImplicitArgsError.implTy2 xs) -> Nat
+fn5 xs offender = foo
+	where
+		barA : Vect 5 ()
+		barB : ImplicitArgsError.implTy2 barA
+		foo : Nat
+-}
+
+{-
+Independence of the other arguments of the function type on the implicit argument does not resolve the situation.
+-}
+implTy4 : Vect n () -> Type
+implTy4 v {n} = {m : Nat} -> Integer
+
+{-
+fn6 : (xs : Vect n ()) -> (offender : implTy4 xs) -> Integer
+fn6 xs offender = foo
+	where
+		barA : Vect 5 ()
+		barB : implTy4 barA
+		foo : Integer
+-}
+
+-- It does not matter if there is no implicit argument to the type-valued function.
+implTy5 : Either () () -> Type
+implTy5 v = {m : Nat} -> Integer
+
+{-
+fn7 : (xs : Either () ()) -> (offender : implTy5 xs) -> Integer
+fn7 xs offender = foo
+	where
+		barA : Either () ()
+		barB : implTy5 barA
+		foo : Integer
+-}
+
+{-
+Finally, when the type-valued function is given explicit parameters in the inner value, you get a relevant error:
+
+"Can't infer argument m1 to offender"
+
+---
+
+fn7 : (xs : Either () ()) -> (offender : implTy5 xs) -> Integer
+fn7 xs offender = foo
+	where
+		bar : implTy5 $ Left ()
+		foo : Integer
+
+-----
+
+... But not if the explicit parameter is specified indirectly.
+
+---
+
+fn8 : (xs : Either () ()) -> (offender : implTy5 xs) -> Integer
+fn8 xs offender = foo
+	where
+		barA : Either () ()
+		barA = Left ()
+		barB : implTy5 barA
+		foo : Integer
+
+-}
+
+{-
+
+Relevant error:
+
+"Can't infer argument m1 to offender"
+
+---
+
+fn9 : (offender : implTy5 $ Left ()) -> Integer
+fn9 offender = foo
+	where
+		foo : Integer
+-}
+
+{-
+Relevant error
+
+	"Can't infer argument m1 to offender"
+
+and no explicit arguments passed to the type-valued function.
+
+---
+
+fn10 : (xs : Either () ()) -> (offender : implTy5 xs) -> Integer
+fn10 xs offender = foo
+	where
+		bar : ()
+		foo : Integer
+-}
+
+{-
+A distinct irrelevant error:
+
+"
+When checking right hand side of fn11 with expected type
+        Integer
+
+No such variable offender
+"
+
+---
+
+fn11 : (xs : Either () ()) -> (offender : implTy5 xs) -> Integer
+fn11 xs offender = offender {m=0}
+-}
+
+{-
+When checking argument l to constructor Prelude.Either.Left:
+        () is not a numeric type
+
+---
+
+fn12 : (offender : implTy5 $ Left 5) -> Integer
+fn12 offender = offender {m=0}
+
+---
+
+fn13 : (offender : implTy5 $ Left 5) -> Integer
+fn13 = (\offender => offender {m=0})
+
+---
+
+fn13 : (offender : implTy5 $ Left 5) -> Integer
+fn13 = (\offender => offender 0)
+
+---
+
+fn14 : (offender : implTy5 $ Left 5) -> Integer
+fn14 = ?fn14'
+-}
+
+{-
+When checking right hand side of fn15 with expected type
+        (xs : Either () ()) -> implTy5 xs -> Integer
+
+No such variable friend
+
+---
+
+fn15 : (xs : Either () ()) -> (offender : implTy5 xs) -> Integer
+fn15 = (\xs => \friend => friend 0)
+
+---
+
+fn16 : (xs : Either () ()) -> (offender : implTy5 xs) -> Integer
+fn16 = (\xs => (\friend => friend {m=0}))
+-}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Contents:
 * `leadingNonzeroCalc`, which takes a `Vect n ZZ` to its first index to a nonzero entry or a proof that all entries are zero.
 * `downAndNotRightOfEntryImpliesZ`, which says a matrix is zero below an index and at or to the left of a second index.
 * Implementation of column-zero elimination, `elimFirstCol : (xs : Matrix n (S predm) ZZ) -> Reader ZZGaussianElimination.gcdOfVectAlg (gexs : Matrix (S n) (S predm) ZZ ** (downAndNotRightOfEntryImpliesZ gexs FZ FZ, bispanslz gexs xs))`.
+* `foldAutoind` - A vector fold over suppressed indices. Extends one witness for some predicate `p : (m : Nat) -> Fin (S m) -> a -> Type` to a `Vect` of them.
+* `foldAutoind2` - Same strength of result as `foldAutoind`, but applies where the predicate `p : (m : Nat) -> Fin (S m) -> (a m) -> Type` isn't naturally expressed or proved without affecting the type of the witnesses dealt with by this process.
 
 ## ZZModuleSpan
 

--- a/README.md
+++ b/README.md
@@ -13,16 +13,20 @@ These show what other kind of theorems are needed, but about the wrong objects t
 ## ZZGaussianElimination
 
 Contents:
-* Declaration of gaussian elimination as an algorithm which converts a matrix into one in row echelon form which spans it. `gaussElimlz : (xs : Matrix n m ZZ) -> (gexs : Matrix n' m ZZ ** (spanslz gexs xs, spanslz xs gexs, rowEchelon gexs))`
+* Declaration of gaussian elimination as an algorithm which converts a matrix into one in row echelon form which spans it. `gaussElimlz : (xs : Matrix n m ZZ) -> (gexs : Matrix n' m ZZ ** (rowEchelon gexs, bispanslz gexs xs))`
 * Implementation of the second property, `rowEchelon`.
 * `leadingNonzeroCalc`, which takes a `Vect n ZZ` to its first index to a nonzero entry or a proof that all entries are zero.
+* `downAndNotRightOfEntryImpliesZ`, which says a matrix is zero below an index and at or to the left of a second index.
+* Implementation of column-zero elimination, `elimFirstCol : (xs : Matrix n (S predm) ZZ) -> Reader ZZGaussianElimination.gcdOfVectAlg (gexs : Matrix (S n) (S predm) ZZ ** (downAndNotRightOfEntryImpliesZ gexs FZ FZ, bispanslz gexs xs))`.
 
 ## ZZModuleSpan
 
 Contents:
 * Definition of the *linearly spans* relation `spanslz` between two Vects of Vects of integers (where integers means inhabitants of Data.ZZ).
+** Its symmetric closure `bispanslz xs ys = (spanslz xs ys, spanslz ys xs)`.
 * Some definitions related to linear spans.
 * Proof of transitivity and reflexivity of `spanslz` using some unproved but known theorems.
+** Their analogues for `bispanslz`, plus proof it's symmetric.
 * Sketches of proof of `zippyScale` associativity in terms of the equivalent matrix multiplication associativity. `zippyScale` is shorthand for a form of linear combination of the rows of a matrix over multiple vectors, as dealt with and proved extensionally equal to matrix multiplication in Data.Matrix.LinearCombinations.
 * Proof of `updateAtEquality : {ls : Matrix n k ZZ} -> {rs : Matrix k m ZZ} -> (updi : Fin n) -> (f : (i : Nat) -> Vect i ZZ -> Vect i ZZ) -> ( (la : Vect k ZZ) -> (f k la) <\> rs = f m $ la <\> rs ) -> zippyScale (updateAt updi (f k) ls) rs = updateAt updi (f m) (zippyScale ls rs)`, which lets you prove `vectMatLScalingCompatibility : {z : ZZ} -> {rs : Matrix k m ZZ} -> (z <#> la) <\> rs = z <#> (la <\> rs)` by a proof that works at least in the REPL, from which `spanRowScalelz : (z : ZZ) -> (updi : Fin n') -> spanslz xs ys -> spanslz xs (updateAt updi (z<#>) ys)` is proved.
 * Many propositions introduced. Towards the end of the file, after section "Proof of relational properties of span", the holes tend to be closer to known properties that will be used directly in the gaussian elimination algorithm, while towards the "Trivial lemmas and plumbing" section at the beginning of the file, the holes are generally strategies proposed for proving theorems about reordering vectors by a permutation, particularly the problem of reaching `spanslzAdditiveExchangeAt : (nel : Fin (S predn)) -> spanslz (updateAt nel (<+>(z<\>(deleteRow nel xs))) xs) xs` from `spanslzAdditiveExchange : spanslz ((y<+>(z<\>xs))::xs) (y::xs)`.

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -591,9 +591,13 @@ Equivalent properties:
 
 weakenDownAndNotRight : (downAndNotRightOfEntryImpliesZ mat (FS prednel) mel) -> (indices (weaken prednel) mel mat = Pos Z) -> downAndNotRightOfEntryImpliesZ mat (weaken prednel) mel
 
+weakenDownAndNotRight_att2 : (downAndNotRightOfEntryImpliesZ mat (FS prednel) mel) -> (indices (FS prednel) mel mat = Pos Z) -> downAndNotRightOfEntryImpliesZ mat (weaken prednel) mel
+
 afterUpdateAtCurStillDownAndNotRight : (downAndNotRightOfEntryImpliesZ mat (FS prednel) mel) -> (downAndNotRightOfEntryImpliesZ (updateAt (weaken prednel) f mat) (FS prednel) mel)
 
 weakenDownAndNotRight2 : (downAndNotRightOfEntryImpliesZ2 mat (FS prednel) mel) -> (indices (weaken prednel) mel mat = Pos Z) -> downAndNotRightOfEntryImpliesZ2 mat (weaken prednel) mel
+
+weakenDownAndNotRight2_att2 : (downAndNotRightOfEntryImpliesZ2 mat (FS prednel) mel) -> (indices (FS prednel) mel mat = Pos Z) -> downAndNotRightOfEntryImpliesZ2 mat (weaken prednel) mel
 
 afterUpdateAtCurStillDownAndNotRight2 : (downAndNotRightOfEntryImpliesZ2 mat (FS prednel) mel) -> (downAndNotRightOfEntryImpliesZ2 (updateAt (weaken prednel) f mat) (FS prednel) mel)
 
@@ -1183,6 +1187,31 @@ elimFirstCol2 mat {n=S predn} {predm} = do {
 				primatzAtWknFi = trans (cong {f=index FZ} $ indexUpdateAtChariz {xs=imat} {i=weaken fi} {f=(<-> (Sigma.getWitness $ fn (weaken fi)) <#> senior)}) $ trans (zipWithEntryChariz {i=FZ {k=predm}} {m=(<+>)} {x=index (weaken fi) imat} {y=inverse $ (Sigma.getWitness $ fn (weaken fi)) <#> senior}) $ trans (cong {f=plusZ $ indices (weaken fi) FZ imat} $ trans (indexCompatInverse ((<#>) (Sigma.getWitness $ fn $ weaken fi) senior) FZ) (cong {f=inverse} $ indexCompatScaling (Sigma.getWitness $ fn $ weaken fi) senior FZ)) $ trans (cong {f=(<->) $ indices (weaken fi) FZ imat} $ trans (cong {f=((Sigma.getWitness $ fn $ weaken fi)<.>)} $ indexFZIsheadValued {xs=senior}) $ getProof $ fn $ weaken fi) $ groupInverseIsInverseL $ indices (weaken fi) FZ imat
 				prfoo : downAndNotRightOfEntryImpliesZ2 witfoo (weaken fi) FZ
 				prfoo = weakenDownAndNotRight2 {prednel=fi} {mel=FZ} {mat=witfoo} (afterUpdateAtCurStillDownAndNotRight2 {mat=imat} {prednel=fi} {mel=FZ} {f=(<-> (Sigma.getWitness $ fn (weaken fi)) <#> senior)} imatDANRZ) primatzAtWknFi
+		-- Including proof the head is equal to senior just makes this step easier.
+		succImplWknStep_modded : ( senior : Vect (S predm) ZZ ) -> ( srQfunc : ( i : Fin _ ) -> (indices i FZ (senior::mat)) `quotientOverZZ` (head senior) )
+			-> (fi : Fin (S predn))
+			-> ( imat : Matrix (S (S predn)) (S predm) ZZ )
+			-> ( senior = head imat, downAndNotRightOfEntryImpliesZ2 {n=S $ S predn} {m=S predm} imat (FS fi) FZ, imat `spanslz` (senior::mat), (senior::mat) `spanslz` imat )
+			-> ( imat' : Matrix (S (S predn)) (S predm) ZZ ** ( senior = head imat', downAndNotRightOfEntryImpliesZ2 {n=S $ S predn} {m=S predm} imat' (weaken fi) FZ, imat' `spanslz` (senior::mat), (senior::mat) `spanslz` imat' ) )
+		succImplWknStep_modded senior srQfunc fi imat ( imatHeadIsSenior, imatDANRZ, imatSpansOrig, origSpansImat ) = (jmat ** ( jmatHeadIsSenior, jmatDANRZ, jmatSpansOrig, origSpansJmat ) )
+			where
+				-- This and thus missingstep can't be implemented. We have used the wrong indexes in our definition of (jmat) and hence in our supporting lemmas for proving jmatDANRZ.
+				degeneracy : fi = FS fi'
+				missingstep : head imat = (Algebra.unity::Algebra.neutral) <\> deleteRow (weaken fi) imat
+				fn : ( j : Fin _ ) -> (indices j FZ imat) `quotientOverZZ` (head senior)
+				fn = succImplWknStep_lemma2_att2 senior srQfunc imat origSpansImat
+				jmat : Matrix (S (S predn)) (S predm) ZZ
+				jmat = updateAt (weaken fi) (<-> (Sigma.getWitness $ fn (weaken fi)) <#> senior) imat
+				jmatHeadIsSenior : senior = head jmat
+				jmatHeadIsSenior = ?succImplWknStep_jmatHeadIsSenior_pr
+				primatzAtWknFi : indices (weaken fi) FZ jmat = Pos Z
+				primatzAtWknFi = trans (cong {f=index FZ} $ indexUpdateAtChariz {xs=imat} {i=weaken fi} {f=(<-> (Sigma.getWitness $ fn (weaken fi)) <#> senior)}) $ trans (zipWithEntryChariz {i=FZ {k=predm}} {m=(<+>)} {x=index (weaken fi) imat} {y=inverse $ (Sigma.getWitness $ fn (weaken fi)) <#> senior}) $ trans (cong {f=plusZ $ indices (weaken fi) FZ imat} $ trans (indexCompatInverse ((<#>) (Sigma.getWitness $ fn $ weaken fi) senior) FZ) (cong {f=inverse} $ indexCompatScaling (Sigma.getWitness $ fn $ weaken fi) senior FZ)) $ trans (cong {f=(<->) $ indices (weaken fi) FZ imat} $ trans (cong {f=((Sigma.getWitness $ fn $ weaken fi)<.>)} $ indexFZIsheadValued {xs=senior}) $ getProof $ fn $ weaken fi) $ groupInverseIsInverseL $ indices (weaken fi) FZ imat
+				jmatDANRZ : downAndNotRightOfEntryImpliesZ2 jmat (weaken fi) FZ
+				jmatDANRZ = weakenDownAndNotRight2 {prednel=fi} {mel=FZ} {mat=jmat} (afterUpdateAtCurStillDownAndNotRight2 {mat=imat} {prednel=fi} {mel=FZ} {f=(<-> (Sigma.getWitness $ fn (weaken fi)) <#> senior)} imatDANRZ) primatzAtWknFi
+				jmatSpansOrig : jmat `spanslz` (senior::mat)
+				jmatSpansOrig = spanslztrans (spanslzreflFromEq {xs=jmat} $ cong {f=\z => updateAt (weaken fi) (<-> z) imat} $ trans ( cong {f=((<#>) {a=ZZ} _)} $ trans imatHeadIsSenior $ missingstep ) $ sym $ vectMatLScalingCompatibility {z=Sigma.getWitness $ fn $ weaken fi} {la=Algebra.unity::Algebra.neutral} {rs=deleteRow (weaken fi) imat}) $ spanslztrans ( spanslzSubtractiveExchangeAt (weaken fi) {xs=imat} {z=(Sigma.getWitness $ fn (weaken fi))<#>(Algebra.unity::Algebra.neutral)} ) $ imatSpansOrig
+				origSpansJmat : (senior::mat) `spanslz` jmat
+				origSpansJmat = ?succImplWknStep_origSpansJmat_pr
 		{-
 		Strategy for proving bispannability of the witness from the above:
 

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -740,8 +740,8 @@ Reference
 gcdOfVectAlg = (k : Nat) -> (x : Vect k ZZ) -> ( v : Vect k ZZ ** ( i : Fin k ) -> (index i x) `quotientOverZZ` (v <:> x) )
 -}
 
-gaussElimlzIfGCD : Reader gcdOfVectAlg ( (xs : Matrix n m ZZ) -> (gexs : Matrix n' m ZZ ** (gexs `spanslz` xs, xs `spanslz` gexs, rowEchelon gexs)) )
--- gaussElimlzIfGCD2 : (xs : Matrix n m ZZ) -> Reader gcdOfVectAlg (gexs : Matrix n' m ZZ ** (gexs `spanslz` xs, xs `spanslz` gexs, rowEchelon gexs))
+gaussElimlzIfGCD : Reader gcdOfVectAlg ( (xs : Matrix n m ZZ) -> (gexs : Matrix n' m ZZ ** (rowEchelon gexs, gexs `bispanslz` xs)) )
+-- gaussElimlzIfGCD2 : (xs : Matrix n m ZZ) -> Reader gcdOfVectAlg (gexs : Matrix n' m ZZ ** (rowEchelon gexs, gexs `bispanslz` xs))
 
 
 
@@ -761,7 +761,7 @@ Main algorithm
 
 
 
-gaussElimlz : (xs : Matrix n m ZZ) -> (gexs : Matrix n' m ZZ ** (gexs `spanslz` xs, xs `spanslz` gexs, rowEchelon gexs))
+gaussElimlz : (xs : Matrix n m ZZ) -> (gexs : Matrix n' m ZZ ** (rowEchelon gexs, gexs `bispanslz` xs))
 gaussElimlz = runIdentity $ runReaderT gaussElimlzIfGCD (\k => gcdOfVectZZ {n=k})
 -- Why is this wrong, for if we put the argument inside the ReaderT gaussElimlzIfGCD?
 -- gaussElimlz = runIdentity . ((flip runReaderT) $ (\k => gcdOfVectZZ {n=k})) . gaussElimlzIfGCD2

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -1064,7 +1064,6 @@ elimFirstCol2 [] {predm} = return ( row {n=S predm} $ neutral ** ( ([] ** Refl),
 		nosuch {i=FZ} {j=FZ} _ = either (const Refl) (const Refl)
 		nosuch {i=FS k} {j=FZ} _ = absurd k
 		nosuch {j=FS k} _ = void . ( either succNotLTEzero SIsNotZ )
-{-
 elimFirstCol2 mat {n=S predn} {predm} = do {
 		gcdalg <- ask @{the (MonadReader ZZGaussianElimination.gcdOfVectAlg _) %instance}
 
@@ -1097,68 +1096,37 @@ elimFirstCol2 mat {n=S predn} {predm} = do {
 		return ( index FZ endmat ** (spanslztrans endmatSpansMatandgcd $ fst bisWithGCD, spanslztrans (snd bisWithGCD) matandgcdSpansEndmat, leftColZBelow))
 	}
 	where
-		succImplWknStep : {v : Vect (S predn) ZZ}
-			-> (fi : Fin nu)
-			-> ( imat : Matrix (S nu) (S predm) ZZ ** ( imat `spanslz` (v <\> mat)::mat, (v <\> mat)::mat `spanslz` imat, downAndNotRightOfEntryImpliesZ imat' (FS fi) FZ ) )
-			-> ( imat' : Matrix (S nu) (S predm) ZZ ** ( imat' `spanslz` (v <\> mat)::mat, (v <\> mat)::mat `spanslz` imat', downAndNotRightOfEntryImpliesZ imat' (weaken fi) FZ ) )
-		foldedFully : {v : Vect (S predn) ZZ} -> ( mats : Vect (S (S predn)) $ Matrix (S (S predn)) (S predm) ZZ ** (i : Fin (S (S predn))) -> succImplWknProp {omat=(v<\>mat)::mat} (S predn) i (index i mats) )
-		-- foldedFully {v} = foldAutoind2 (succImplWknProp {omat=(v <\> mat)::mat}) (succImplWknStep {v=v}) ( (v<\>mat)::mat ** (spanslzrefl, spanslzrefl, danrzLast {omat=(v <\> mat)::mat}) )
--}
-elimFirstCol2 mat {n=S predn} {predm} = do {
-		gcdalg <- ask @{the (MonadReader ZZGaussianElimination.gcdOfVectAlg _) %instance}
-
-		-- (v ** fn) : ( v : Vect _ ZZ ** ( i : Fin _ ) -> (index i matcolZ) `quotientOverZZ` (v <:> matcolZ) )
-		let (v ** fn) = runGCDOfVectAlg gcdalg _ (getCol FZ mat)
-
-		let bisWithGCD = the ((v<\>mat)::mat `spanslz` mat, mat `spanslz` (v<\>mat)::mat)
-			(extendSpanningLZsByPreconcatTrivially {zs=[_]} spanslzrefl, mergeSpannedLZs spanslzRowTimesSelf spanslzrefl)
-
 		{-
-		The error here is indecipherable from the message. See the form below for an improvement.
-		---
-		let ( endmat ** endmatPropFn ) = foldAutoind2 (succImplWknProp {omat=(v <\> mat)::mat}) (succImplWknStep {v=v}) ( (v<\>mat)::mat ** (spanslzrefl, spanslzrefl, the ( downAndNotRightOfEntryImpliesZ ((v<\>mat)::mat) (last {n=predn}) FZ ) $ void . notSNatLastLTEAnything) )
-		
-		---
-		Here it's basically telling us it can't infer a function type for succImplWknProp _ _ _.
-		---
-		let ( endmat ** endmatPropFn ) = foldAutoind2 (succImplWknProp {omat=(v <\> mat)::mat}) (succImplWknStep {v=v}) ( (v<\>mat)::mat ** (spanslzrefl, spanslzrefl, the ( succImplWknProp {omat=(v<\>mat)::mat} (S predn) (last {n=predn}) ((v<\>mat)::mat) ) ( void . notSNatLastLTEAnything )) )
-		
-		---
-		After much externalization for error isolation
-		---
-		let ( endmat ** endmatPropFn ) = foldAutoind2 (succImplWknProp {omat=(v <\> mat)::mat}) (succImplWknStep {v=v}) ( (v<\>mat)::mat ** (spanslzrefl, spanslzrefl, danrzLast {omat=(v <\> mat)::mat}) )
+		!!! This (succImplWknStep) is dead code, retained for (foldedFully).
+		!!! See (succImplWknStep_att2) and (foldedFully_att2) for living code.
 		-}
-
-		let ( endmat ** endmatPropFn ) = foldedFully {v=v}
-
-		let ( endmatSpansMatandgcd, matandgcdSpansEndmat, leftColZBelow ) = endmatPropFn FZ
-
-		return ( index FZ endmat ** (spanslztrans endmatSpansMatandgcd $ fst bisWithGCD, spanslztrans (snd bisWithGCD) matandgcdSpansEndmat, leftColZBelow))
-	}
-	where
 		succImplWknStep : {v : Vect (S predn) ZZ}
 			-> (fi : Fin (S predn))
 			-> ( imat : Matrix (S (S predn)) (S predm) ZZ ** ( imat `spanslz` (v <\> mat)::mat, (v <\> mat)::mat `spanslz` imat, downAndNotRightOfEntryImpliesZ imat (FS fi) FZ ) )
 			-> ( imat' : Matrix (S (S predn)) (S predm) ZZ ** ( imat' `spanslz` (v <\> mat)::mat, (v <\> mat)::mat `spanslz` imat', downAndNotRightOfEntryImpliesZ imat' (weaken fi) FZ ) )
-		succImplWknStep_lemma1 : ( senior : Vect (S predm) ZZ ) -> ( srQfunc : ( i : Fin _ ) -> (indices i FZ (senior::mat)) `quotientOverZZ` (head senior) )
-			-> (fi : Fin (S predn))
-			-> ( imat : Matrix (S (S predn)) (S predm) ZZ ** ( imat `spanslz` senior::mat, senior::mat `spanslz` imat, downAndNotRightOfEntryImpliesZ imat (FS fi) FZ ) )
-			-> ( imat' : Matrix (S (S predn)) (S predm) ZZ ** ( downAndNotRightOfEntryImpliesZ imat' (weaken fi) FZ ) )
-		succImplWknStep_lemma1 = ?succImplWknStep_lemma1_pr
-		succImplWknStep_lemma2 : ( senior : Vect (S predm) ZZ ) -> ( srQfunc : ( i : Fin _ ) -> (indices i FZ (senior::mat)) `quotientOverZZ` (head senior) )
-			-> (fi : Fin (S predn))
-			-> ( imat : Matrix (S (S predn)) (S predm) ZZ )
-			-> ( reprolem : senior::mat `spanslz` imat )
-			-> ( ( j : Fin _ ) -> (indices j FZ imat) `quotientOverZZ` (head senior) )
-		succImplWknStep_lemma2 = ?succImplWknStep_lemma2_pr
-		succImplWknStep_lemma3 : ( senior : Vect (S predm) ZZ ) -> ( srQfunc : ( i : Fin _ ) -> (indices i FZ (senior::mat)) `quotientOverZZ` (head senior) )
-			-> (fi : Fin (S predn))
-			-> ( imat : Matrix (S (S predn)) (S predm) ZZ )
-			-> ( z : Matrix _ _ ZZ )
-			-> ( quotchariz : ( k : Fin _ ) -> ( LinearCombinations.monoidsum $ zipWith (<#>) (index k z) (senior::mat) = index k imat ) )
-			-> ( ( j : Fin _ ) -> (indices j FZ imat) `quotientOverZZ` (head senior) )
-		succImplWknStep_lemma3 = ?succImplWknStep_lemma3_pr
-		-- linearComboQuotientRelation
+		{-
+		Section notes for succImplWknStep_att2
+
+		---
+
+		Structure:
+		lemma3 => lemma2 => lemma1 => succImplWknStep_att2 => foldedFully_att2
+		(incomplete picture)
+
+		---
+
+		We have learned of two obstructions to expressing (succImplWknStep_att2) and its lemmas which must be taken into account in this design.
+
+		1) If a dependent pair's proof's type is a function of the witness and has implicit arguments, that dependent pair will not be inferred correctly when used as an argument to a function, and this might only be revealed through type errors in (the left-hand side of) other definitions that are attempted within the function, such as in its where block, where such definitions have the arguments to the function in their assumptions/context (environment, scope).
+
+			See (ImplicitArgsError) for simple examples of the problem.
+
+			Implementing (foldAutoInd) created a similar problem when using type-valued functions that took certain implicit arguments, which led to writing (foldAutoInd[2-3]) instead. However, the values of those type-valued functions did not clearly have implicit arguments.
+
+		2) A triple of types in the righthand value of a dependent pair is not treated as a type when pattern matching on it, giving type errors when anything is done with the proof (getProof _) except using it as an argument to a function. Hence to get a function from dependent pairs to dependent pairs that applies the theorem proved, we must call a dependently typed but curried version of the function on the witness and proof of the dependent pair input. Whence (succImplWknStep_unplumbed) and the definition of (succImplWknStep) in terms of it.
+
+			Note, we may write (the Type (Nat,Nat,Nat)), but using a predefined (Type) whose value is a triple does not get around the mismatch error.
+		-}
 		succImplWknStep_lemma3_att2 : ( senior : Vect (S predm) ZZ ) -> ( srQfunc : ( i : Fin _ ) -> (indices i FZ (senior::mat)) `quotientOverZZ` (head senior) )
 			-> ( imat : Matrix (S (S predn)) (S predm) ZZ )
 			-> ( z : Matrix _ _ ZZ )
@@ -1184,158 +1152,12 @@ elimFirstCol2 mat {n=S predn} {predm} = do {
 			-> ( reprolem : senior::mat `spanslz` imat )
 			-> ( ( j : Fin _ ) -> (indices j FZ imat) `quotientOverZZ` (head senior) )
 		succImplWknStep_lemma2_att2 senior srQfunc imat reprolem = succImplWknStep_lemma3_att2 senior srQfunc imat (getWitness reprolem) (\k => trans (sym indexMapChariz) $ cong {f=index k} $ getProof reprolem)
-		succImplWknStep_lemma1_att2 : ( senior : Vect (S predm) ZZ ) -> ( srQfunc : ( i : Fin _ ) -> (indices i FZ (senior::mat)) `quotientOverZZ` (head senior) )
-			-> (fi : Fin (S predn))
-			-> ( imat : Matrix (S (S predn)) (S predm) ZZ ** ( imat `spanslz` (senior::mat), (senior::mat) `spanslz` imat, downAndNotRightOfEntryImpliesZ imat (FS fi) FZ ) )
-			-> ( imat' : Matrix (S (S predn)) (S predm) ZZ ** ( downAndNotRightOfEntryImpliesZ imat' (weaken fi) FZ ) )
 		{-
-		Type checking bug:
-
-		Although (imatpr3) only occurs through pattern match, we still get this error
-
-		When checking type of ZZGaussianElimination.elimFirstCol2, succImplWknStep_lemma1_att2, prDown:
-		Type mismatch between
-		        LTE (S (S (finToNat fi))) (finToNat i29) ->
-		        Either (LTE (S (finToNat j)) 0) (finToNat j = 0) ->
-		        index j (index i29 imat) = Pos 0 (Type of imatpr3)
-		and
-		        LTE (S (S (finToNat fi))) (finToNat i30) ->
-		        Either (LTE (S (finToNat j1)) 0) (finToNat j1 = 0) ->
-		        index j1 (index i30 imat) = Pos 0 (Expected type)
-
-		Specifically:
-		        Type mismatch between
-		                Fin (S (S predn))
-		        and
-		                LTE (S (S (finToNat fi))) (finToNat i30)
-
-		---
-
-		succImplWknStep_lemma1_att2 senior srQfunc fi (imat ** (imatpr1, imatpr2, imatpr3)) = ( updateAt (weaken fi) (<-> (head senior)<.>(Sigma.getWitness $ fn (weaken fi)) <#> index (weaken fi) imat) imat ** prDown )
-			where
-				fn : ( j : Fin _ ) -> (indices j FZ imat) `quotientOverZZ` (head senior)
-				fn = succImplWknStep_lemma2_att2 senior srQfunc imat imatpr2
-				prDown : downAndNotRightOfEntryImpliesZ ( updateAt (weaken fi) (<-> (head senior)<.>(Sigma.getWitness $ fn (weaken fi)) <#> index (weaken fi) imat) imat ) (weaken fi) FZ
-		
-
-		-----
-
-
-		This one didn't work either. It's almost certainly that (succImplWknStep_lemma1_att2) was declared a malformed type.
-
-		However, the type can be evaluated in the REPL without complaint.
-
-		> (predm, predn : Nat) -> (mat : Matrix (S predn) (S predm) ZZ) -> ( senior : Vect (S predm) ZZ ) -> ( srQfunc : ( i : Fin _ ) -> (indices i FZ (senior::mat)) `quotientOverZZ` (head senior) ) -> (fi : Fin (S predn)) -> ( imat : Matrix (S (S predn)) (S predm) ZZ ** ( imat `spanslz` (senior::mat), (senior::mat) `spanslz` imat, downAndNotRightOfEntryImpliesZ imat (FS fi) FZ ) ) -> ( imat' : Matrix (S (S predn)) (S predm) ZZ ** ( downAndNotRightOfEntryImpliesZ imat' (weaken fi) FZ ) )
-
-		It could be the pattern matching itself that's flawed.
-
-		---
-
-		succImplWknStep_lemma1_att2 senior srQfunc fi (imat ** (imatpr1, imatpr2, imatpr3)) ?= ( updateAt (weaken fi) (<-> (head senior)<.>(Sigma.getWitness $ fn (weaken fi)) <#> index (weaken fi) imat) imat ** weakenDownAndNotRight {prednel=fi} {mel=FZ} {mat=updateAt (weaken fi) (<-> (head senior)<.>(Sigma.getWitness $ fn (weaken fi)) <#> index (weaken fi) imat) imat} (afterUpdateAtCurStillDownAndNotRight {mat=imat} {f=(<-> (head senior)<.>(Sigma.getWitness $ fn (weaken fi)) <#> index (weaken fi) imat)} {prednel=fi} {mel=FZ} imatpr3) zeroAfterSubPr )
-			where
-				fn : ( j : Fin _ ) -> (indices j FZ imat) `quotientOverZZ` (head senior)
-				fn = succImplWknStep_lemma2_att2 senior srQfunc imat imatpr2
-				zeroAfterSubPr : indices (weaken fi) FZ $ updateAt (weaken fi) (<-> (head senior)<.>(Sigma.getWitness $ fn (weaken fi)) <#> index (weaken fi) imat) imat = Pos Z
-
-
-		-----
-
-
-		Same error:
-
-		succImplWknStep_lemma1_att2 senior srQfunc fi (imat ** ( imatpr1, (imatpr2, imatpr3) )) = (fafa ** sese)
-			where
-				fafa : Matrix (S (S predn)) (S predm) ZZ
-				sese : downAndNotRightOfEntryImpliesZ fafa (weaken fi) FZ
-
-
-		-----
-
-		Nope:
-
-		succImplWknStep_lemma1_att2 senior srQfunc fi (imat ** ( imatpr1, imatpr2, imatpr3 )) = foo
-			where
-				witfoo : Matrix (S (S predn)) (S predm) ZZ
-				prfoo : downAndNotRightOfEntryImpliesZ witfoo (weaken fi) FZ
-				foo : ( imat' : Matrix (S (S predn)) (S predm) ZZ ** downAndNotRightOfEntryImpliesZ imat' (weaken fi) FZ )
-				-- foo ?= ( witfoo ** prfoo )
-				-- foo ?= MkSigma witfoo {P=\matty => downAndNotRightOfEntryImpliesZ matty (weaken fi) FZ} prfoo
-		
-		-----
-
-		Error eliminated by just not pattern matching on dependent pair like that, but now we have a scarier problem.
-
-		succImplWknStep_lemma1_att2 senior srQfunc fi imatAndPrs = foo
-			where
-				imat : Matrix (S (S predn)) (S predm) ZZ
-				imat = getWitness imatAndPrs
-				imatZPr : downAndNotRightOfEntryImpliesZ imat (FS fi) FZ
-				imatZPr ?= snd $ snd $ getProof imatAndPrs
-				witfoo : Matrix (S (S predn)) (S predm) ZZ
-				prfoo : downAndNotRightOfEntryImpliesZ witfoo (weaken fi) FZ
-				foo : ( imat' : Matrix (S (S predn)) (S predm) ZZ ** downAndNotRightOfEntryImpliesZ imat' (weaken fi) FZ )
-				-- foo ?= ( witfoo ** prfoo )
-				-- foo ?= MkSigma witfoo {P=\matty => downAndNotRightOfEntryImpliesZ matty (weaken fi) FZ} prfoo
-
-		-----
-
-		Either of these will give
-
-		ZZGaussianElimination.idr:1223:45:Type mismatch between
-		        Vect (S predm) ZZ
-		and
-		        ZZ
-
-		succImplWknStep_lemma1_att2 senior srQfunc fi imatAndPrs with ( imatAndPrs )
-			| (imat ** (_,_,imatZPr)) = ?adadadep -- ( imat' ** imatZPr' )
-
-		succImplWknStep_lemma1_att2 senior srQfunc fi imatAndPrs with ( imatAndPrs )
-			| ( suluOfRnfrst ** valley ) = ?adadadep
-
-		-----
-
-		This will cause the same error once (fn) is left to be proved.
-		It appears to be fixed if you use (compute) at this stage before (exact ?hoelele), but if you don't solve (fn) right then and unfocus as required, the error appears anyway once it's solved as the last goal.
-
-		succImplWknStep_lemma1_att2 = ?succImplWknStep_lemma1_att2_pr
-
-		succImplWknStep_lemma1_att2_pr = proof
-		  intro
-		  intro
-		  intro
-		  intro
-		  intro
-		  intro
-		  intro imatAndPr
-		  let imatty = getWitness imatAndPr
-		  let imattyZPr = snd $ snd $ getProof imatAndPr
-		  claim fn ( j : Fin _ ) -> (indices j FZ imatty) `quotientOverZZ` (head senior)
-		  unfocus
-		  exact ( updateAt (weaken fi) (<-> (head senior)<.>(Sigma.getWitness $ fn (weaken fi)) <#> index (weaken fi) imatty) imatty ** _ )
-		  unfocus
-		  exact weakenDownAndNotRight {prednel=fi} {mel=FZ} _ _
-		  unfocus
-		  exact updateAt (weaken fi) (<-> (head senior)<.>(Sigma.getWitness $ fn (weaken fi)) <#> index (weaken fi) imatty) imatty
-		  exact afterUpdateAtCurStillDownAndNotRight {mat=imatty} {prednel=fi} {mel=FZ} _
-		  exact ?stipulation1
-		  intro jah
-		  exact believe_me "Hello."
-		  exact imattyZPr
-
-
-
-		-----
-
-
-		As for the contents of the proof, I now think instead of
-
-		> updateAt (weaken fi) (<-> (head senior)<.>(Sigma.getWitness $ fn (weaken fi)) <#> index (weaken fi) imat) imat
-
-		it should be
+		For the proof of (downAndNotRightImpliesZ2) for the output of the below function in human, consider the modification
 
 		> updateAt (weaken fi) (<-> (Sigma.getWitness $ fn (weaken fi)) <#> senior) imat
 
-		since according to (fn $ weaken fi), we will then get a value (imat') such that
+		to imat. According to (fn $ weaken fi), we will get a value (imat') such that
 
 		> indices (weaken fi) FZ imat'
 			= head $ index (weaken fi) imat <-> (Sigma.getWitness $ fn (weaken fi)) <#> senior
@@ -1345,187 +1167,7 @@ elimFirstCol2 mat {n=S predn} {predm} = do {
 				head (index (weaken fi) imat) <-> head (index (weaken fi) imat)
 			=	(by groupInverseIsInverseL $ head (index (weaken fi) imat))
 			Pos Z
-
 		-}
-		succImplWknStep_lemma1_att2 = ?succImplWknStep_lemma1_att2_pr
-		{-
-		Strategy visible for proving bispannability for the witness from above:
-
-		< sym vectMatLScalingCompatibility
-
-		extends a proof that (index (weaken fi) imat)
-
-		is of the form (v <\> tau)
-
-		to a proof that for all s,
-
-		< s<#>(index (weaken fi) imat)
-
-		is of the form (v <\> tau).
-
-		Then (spanslzSubtractiveExchangeAt (weaken fi)) (or its bispanning version) can be applied to produce the spanslz proofs, for (tau = deleteRow (weaken fi) imat).
-		-}
-		{-
-
-		Based on our experience with (foldAutoInd) vs. (foldAutoInd[2-3]), there are problems with taking Sigma arguments where the property-producing function takes implicit arguments. In that case it was implicit arguments to the function, but since implicit arguments are involved in the value itself we may have to eliminate those as well.
-
-		So, the first thing we should try is the following:
-
-		> downAndNotRightOfEntryImpliesZ : (xs : Matrix n m ZZ) -> (row : Fin n) -> (col : Fin m) -> Type
-
-		> downAndNotRightOfEntryImpliesZ_MatchVariant : (n, m : Nat) -> (xs : Matrix n m ZZ) -> (row : Fin n) -> (col : Fin m) -> Type
-
-		and then let {P=\xsInDANRZ => downAndNotRightOfEntryImpliesZ_MatchVariant _ _ xsInDANRZ _ _} for the Sigma type, modifying this for dependent pair syntax to
-
-		> ( xs : Matrix n m ZZ ** (\xsInDANRZ => downAndNotRightOfEntryImpliesZ_MatchVariant n m xsInDANRZ i j) xs )
-
-		or simply
-
-		> ( xs : Matrix n m ZZ ** (\xsInDANRZ => downAndNotRightOfEntryImpliesZ {n=n} {m=m} xsInDANRZ i j) xs )
-
-		---
-
-		succImplWknStep_lemma1_att3 : ( senior : Vect (S predm) ZZ ) -> ( srQfunc : ( i : Fin _ ) -> (indices i FZ (senior::mat)) `quotientOverZZ` (head senior) )
-			-> (fi : Fin (S predn))
-			-> ( imat : Matrix (S (S predn)) (S predm) ZZ ** (\xsInProp => ( xsInProp `spanslz` (senior::mat), (senior::mat) `spanslz` xsInProp, downAndNotRightOfEntryImpliesZ {n=S $ S predn} {m=S predm} xsInProp (FS fi) FZ )) imat )
-			-> ( imat' : Matrix (S (S predn)) (S predm) ZZ ** ( (\xsInProp => downAndNotRightOfEntryImpliesZ {n=S $ S predn} {m=S predm} xsInProp (weaken fi) FZ) imat' ) )
-
-		-----
-
-		This successfully uncovers that there is a problem with specifying this as a Sigma type at all:
-
-		When checking argument P to type constructor Builtins.Sigma:
-		        Type mismatch between
-		                (Type, Type, Type) (Type of (\xsInProp =>
-		                                               (spanslz xsInProp
-		                                                        (senior :: mat),
-		                                                spanslz (senior :: mat)
-		                                                        xsInProp,
-		                                                downAndNotRightOfEntryImpliesZ xsInProp
-		                                                                               (FS fi)
-		                                                                               FZ)) imat)
-		        and
-		                Type (Expected type)
-
-		---
-
-		This is a silly error, though.
-
-		> (Nat, Nat, Nat) : (Type, Type, Type)
-
-		> the Type (Nat, Nat, Nat) : Type
-
-		---
-
-		Nevertheless, it creates an impassable barrier:
-
-		succImplWknStep_lemma1_att4 : ( senior : Vect (S predm) ZZ ) -> ( srQfunc : ( i : Fin _ ) -> (indices i FZ (senior::mat)) `quotientOverZZ` (head senior) )
-			-> (fi : Fin (S predn))
-			-> ( imat : Matrix (S (S predn)) (S predm) ZZ ** (\xsInProp => the Type ( xsInProp `spanslz` (senior::mat), (senior::mat) `spanslz` xsInProp, downAndNotRightOfEntryImpliesZ {n=S $ S predn} {m=S predm} xsInProp (FS fi) FZ )) imat )
-			-> ( imat' : Matrix (S (S predn)) (S predm) ZZ ** ( (\xsInProp => downAndNotRightOfEntryImpliesZ {n=S $ S predn} {m=S predm} xsInProp (weaken fi) FZ) imat' ) )
-		succImplWknStep_lemma1_att4 senior srQfunc fi (imat ** imatPrs) = foo
-			where
-				fn : ( j : Fin _ ) -> (indices j FZ imat) `quotientOverZZ` (head senior)
-				witfoo : Matrix (S (S predn)) (S predm) ZZ
-				prfoo : downAndNotRightOfEntryImpliesZ witfoo (weaken fi) FZ
-				-- foo : ( imat' : Matrix (S (S predn)) (S predm) ZZ ** downAndNotRightOfEntryImpliesZ imat' (weaken fi) FZ )
-				foo : ( imat' : Matrix (S (S predn)) (S predm) ZZ ** (\xsInProp => downAndNotRightOfEntryImpliesZ {n=S $ S predn} {m=S predm} xsInProp (weaken fi) FZ) imat' )
-
-		---
-
-		When checking type of ZZGaussianElimination.elimFirstCol2, succImplWknStep_lemma1_att4, fn:
-		Type mismatch between
-		        (Type, Type, Type) (Type of ...)
-		and
-		        Type (Expected type)
-
-		-----
-
-		The following two still give this displaced error, suggesting a problem with the types produced by (downAndNotRightOfEntryImpliesZ) itself, rather than with the way we're pattern matching on types like this:
-
-		When checking type of ZZGaussianElimination.elimFirstCol2, succImplWknStep_lemma1_att5, prfoo:
-		Type mismatch between
-		        downAndNotRightOfEntryImpliesZ imat (FS fi) FZ
-		and
-		        (\i =>
-		           LTE (S (S (finToNat fi))) (finToNat i) ->
-		           Either (LTE (S (finToNat j)) 0) (finToNat j = 0) ->
-		           index j (index i imat) = Pos 0) i1
-
-		---
-
-		succImplWknStep_lemma1_att5 : ( senior : Vect (S predm) ZZ ) -> ( srQfunc : ( i : Fin _ ) -> (indices i FZ (senior::mat)) `quotientOverZZ` (head senior) )
-			-> ( fi : Fin (S predn) )
-			-> ( imat : Matrix (S (S predn)) (S predm) ZZ )
-			-> ( imatSpansOrig : imat `spanslz` (senior::mat) )
-			-> ( origSpansImat : (senior::mat) `spanslz` imat )
-			-> ( imatDANRZ : downAndNotRightOfEntryImpliesZ {n=S $ S predn} {m=S predm} imat (FS fi) FZ )
-			-> ( imot : Matrix (S (S predn)) (S predm) ZZ ** (\xsInProp => downAndNotRightOfEntryImpliesZ {n=S $ S predn} {m=S predm} xsInProp (weaken fi) FZ) imot )
-		succImplWknStep_lemma1_att5 senior srQfunc fi imat imatSpansOrig origSpansImat imatDANRZ = foo
-			where
-				fn : ( j : Fin _ ) -> (indices j FZ imat) `quotientOverZZ` (head senior)
-				witfoo : Matrix (S (S predn)) (S predm) ZZ
-				witfoo = ?witfoo'
-				prfoo : downAndNotRightOfEntryImpliesZ witfoo (weaken fi) FZ
-				-- foo : ( imat' : Matrix (S (S predn)) (S predm) ZZ ** downAndNotRightOfEntryImpliesZ imat' (weaken fi) FZ )
-				foo : ( imot : Matrix (S (S predn)) (S predm) ZZ ** (\xsInProp => downAndNotRightOfEntryImpliesZ {n=S $ S predn} {m=S predm} xsInProp (weaken fi) FZ) imot )
-
-		---
-
-		succImplWknStep_lemma1_att5 : ( senior : Vect (S predm) ZZ ) -> ( srQfunc : ( i : Fin _ ) -> (indices i FZ (senior::mat)) `quotientOverZZ` (head senior) )
-			-> ( fi : Fin (S predn) )
-			-> ( imat : Matrix (S (S predn)) (S predm) ZZ )
-			-> ( imatSpansOrig : imat `spanslz` (senior::mat) )
-			-> ( origSpansImat : (senior::mat) `spanslz` imat )
-			-> ( imatDANRZ : downAndNotRightOfEntryImpliesZ {n=S $ S predn} {m=S predm} imat (FS fi) FZ )
-			-> Nat
-		succImplWknStep_lemma1_att5 senior srQfunc fi imat imatSpansOrig origSpansImat imatDANRZ = foo
-			where
-				-- fn : ( j : Fin _ ) -> (indices j FZ imat) `quotientOverZZ` (head senior)
-				witfoo : Matrix (S (S predn)) (S predm) ZZ
-				witfoo = ?witfoo'
-				-- prfoo : downAndNotRightOfEntryImpliesZ witfoo (weaken fi) FZ
-				-- prfoo : (\xsPrFoo => downAndNotRightOfEntryImpliesZ xsPrFoo (weaken fi) FZ) witfoo
-				prfoo : (\xsPrFoo => downAndNotRightOfEntryImpliesZ {n=S $ S predn} {m=S predm} xsPrFoo (weaken fi) FZ) witfoo
-				foo : Nat
-
-		---
-
-		In fact, with the type errors from the different ways of declaring the type of (prfoo), these different ways seen in the last version, it seems to suggest that as imatDANRZ is having its type inferred in the environment of other, locally-declared values' types, its type's implicit arguments are being made explicit in either those environments XOR the type inferred for imatDANRZ (upon pattern matching or in inferring the type of succImplWknStep_lemma1_att5).
-
-		So, I think we're forced to rewrite (downAndNotRightOfEntryImpliesZ) so that the arguments of its values are all explicit.
-
-		-}
-		{-
-		This old workaround still gives the type error that the type is a triple of types not interpreted as a type in its own right. Very sad. Isn't helped if (downAndNotRightImpliesZ2) is used instead of (downAndNotRightImpliesZ), either.
-
-		---
-
-		succImplWknStep_lemma1_att6 : ( senior : Vect (S predm) ZZ ) -> ( srQfunc : ( i : Fin _ ) -> (indices i FZ (senior::mat)) `quotientOverZZ` (head senior) )
-			-> ( fi : Fin (S predn) )
-			-> ( imat : Matrix (S (S predn)) (S predm) ZZ ** succImplWknProp {omat=senior::mat} (S predn) (FS fi) imat )
-			-> ( imat' : Matrix (S (S predn)) (S predm) ZZ ** succImplWknPropSec3 {omat=senior::mat} (S predn) (weaken fi) imat' )
-		succImplWknStep_lemma1_att6 senior srQfunc fi (imat ** imatprs) = foo
-			where
-				foo : ( imat' : Matrix (S (S predn)) (S predm) ZZ ** succImplWknPropSec3 {omat=senior::mat} (S predn) (weaken fi) imat' )
-		-}
-		succImplWknStep_lemma1_att7 : ( senior : Vect (S predm) ZZ ) -> ( srQfunc : ( i : Fin _ ) -> (indices i FZ (senior::mat)) `quotientOverZZ` (head senior) )
-			-> (fi : Fin (S predn))
-			-> ( imat : Matrix (S (S predn)) (S predm) ZZ )
-			-> ( imatSpansOrig : imat `spanslz` (senior::mat) )
-			-> ( origSpansImat : (senior::mat) `spanslz` imat )
-			-> ( imatDANRZ : downAndNotRightOfEntryImpliesZ2 {n=S $ S predn} {m=S predm} imat (FS fi) FZ )
-			-> ( imat' : Matrix (S (S predn)) (S predm) ZZ ** downAndNotRightOfEntryImpliesZ2 {n=S $ S predn} {m=S predm} imat' (weaken fi) FZ )
-		succImplWknStep_lemma1_att7 senior srQfunc fi imat imatSpansOrig origSpansImat imatDANRZ = (witfoo ** prfoo)
-			where
-				fn : ( j : Fin _ ) -> (indices j FZ imat) `quotientOverZZ` (head senior)
-				fn = succImplWknStep_lemma2_att2 senior srQfunc imat origSpansImat
-				witfoo : Matrix (S (S predn)) (S predm) ZZ
-				witfoo = updateAt (weaken fi) (<-> (Sigma.getWitness $ fn (weaken fi)) <#> senior) imat
-				primatzAtWknFi : indices (weaken fi) FZ witfoo = Pos Z
-				primatzAtWknFi = trans (cong {f=index FZ} $ indexUpdateAtChariz {xs=imat} {i=weaken fi} {f=(<-> (Sigma.getWitness $ fn (weaken fi)) <#> senior)}) $ trans (zipWithEntryChariz {i=FZ {k=predm}} {m=(<+>)} {x=index (weaken fi) imat} {y=inverse $ (Sigma.getWitness $ fn (weaken fi)) <#> senior}) $ trans (cong {f=plusZ $ indices (weaken fi) FZ imat} $ trans (indexCompatInverse ((<#>) (Sigma.getWitness $ fn $ weaken fi) senior) FZ) (cong {f=inverse} $ indexCompatScaling (Sigma.getWitness $ fn $ weaken fi) senior FZ)) $ trans (cong {f=(<->) $ indices (weaken fi) FZ imat} $ trans (cong {f=((Sigma.getWitness $ fn $ weaken fi)<.>)} $ indexFZIsheadValued {xs=senior}) $ getProof $ fn $ weaken fi) $ groupInverseIsInverseL $ indices (weaken fi) FZ imat
-				prfoo : downAndNotRightOfEntryImpliesZ2 witfoo (weaken fi) FZ
-				prfoo = weakenDownAndNotRight2 {prednel=fi} {mel=FZ} {mat=witfoo} (afterUpdateAtCurStillDownAndNotRight2 {mat=imat} {prednel=fi} {mel=FZ} {f=(<-> (Sigma.getWitness $ fn (weaken fi)) <#> senior)} imatDANRZ) primatzAtWknFi
 		succImplWknStep_lemma1_att8 : ( senior : Vect (S predm) ZZ ) -> ( srQfunc : ( i : Fin _ ) -> (indices i FZ (senior::mat)) `quotientOverZZ` (head senior) )
 			-> (fi : Fin (S predn))
 			-> ( imat : Matrix (S (S predn)) (S predm) ZZ )
@@ -1541,16 +1183,35 @@ elimFirstCol2 mat {n=S predn} {predm} = do {
 				primatzAtWknFi = trans (cong {f=index FZ} $ indexUpdateAtChariz {xs=imat} {i=weaken fi} {f=(<-> (Sigma.getWitness $ fn (weaken fi)) <#> senior)}) $ trans (zipWithEntryChariz {i=FZ {k=predm}} {m=(<+>)} {x=index (weaken fi) imat} {y=inverse $ (Sigma.getWitness $ fn (weaken fi)) <#> senior}) $ trans (cong {f=plusZ $ indices (weaken fi) FZ imat} $ trans (indexCompatInverse ((<#>) (Sigma.getWitness $ fn $ weaken fi) senior) FZ) (cong {f=inverse} $ indexCompatScaling (Sigma.getWitness $ fn $ weaken fi) senior FZ)) $ trans (cong {f=(<->) $ indices (weaken fi) FZ imat} $ trans (cong {f=((Sigma.getWitness $ fn $ weaken fi)<.>)} $ indexFZIsheadValued {xs=senior}) $ getProof $ fn $ weaken fi) $ groupInverseIsInverseL $ indices (weaken fi) FZ imat
 				prfoo : downAndNotRightOfEntryImpliesZ2 witfoo (weaken fi) FZ
 				prfoo = weakenDownAndNotRight2 {prednel=fi} {mel=FZ} {mat=witfoo} (afterUpdateAtCurStillDownAndNotRight2 {mat=imat} {prednel=fi} {mel=FZ} {f=(<-> (Sigma.getWitness $ fn (weaken fi)) <#> senior)} imatDANRZ) primatzAtWknFi
-		succImplWknStep_lemma1_plumbed : ( senior : Vect (S predm) ZZ ) -> ( srQfunc : ( i : Fin _ ) -> (indices i FZ (senior::mat)) `quotientOverZZ` (head senior) )
+		{-
+		Strategy for proving bispannability of the witness from the above:
+
+		< sym vectMatLScalingCompatibility
+
+		extends a proof that (senior)
+
+		is of the form (v_imat <\> tau)
+
+		to a proof that for all s,
+
+		< s<#>senior
+
+		is of the form (v_imat <\> tau).
+
+		Then (spanslzSubtractiveExchangeAt (weaken fi)) (or its bispanning version) can be applied to produce the spanslz proofs, for (tau = deleteRow (weaken fi) imat).
+		-}
+		succImplWknStep_unplumbed : (v : Vect (S predn) ZZ)
+			-> ( vmatQfunc : ( i : Fin _ ) -> (indices i FZ ((v <\> mat)::mat)) `quotientOverZZ` (head $ v <\> mat) )
 			-> (fi : Fin (S predn))
-			-> ( imat : Matrix (S (S predn)) (S predm) ZZ ** ( downAndNotRightOfEntryImpliesZ2 {n=S $ S predn} {m=S predm} imat (FS fi) FZ, imat `spanslz` (senior::mat), (senior::mat) `spanslz` imat ) )
-			-> ( imat' : Matrix (S (S predn)) (S predm) ZZ ** downAndNotRightOfEntryImpliesZ2 {n=S $ S predn} {m=S predm} imat' (weaken fi) FZ )
-		succImplWknStep_lemma1_plumbed senior srQfunc fi imatAndPr = succImplWknStep_lemma1_att8 senior srQfunc fi (getWitness imatAndPr) (getProof imatAndPr)
+			-> ( imat : Matrix (S (S predn)) (S predm) ZZ )
+			-> ( downAndNotRightOfEntryImpliesZ2 imat (FS fi) FZ, imat `spanslz` (v <\> mat)::mat, (v <\> mat)::mat `spanslz` imat )
+			-> ( imat' : Matrix (S (S predn)) (S predm) ZZ ** ( downAndNotRightOfEntryImpliesZ2 imat' (weaken fi) FZ, imat' `spanslz` (v <\> mat)::mat, (v <\> mat)::mat `spanslz` imat' ) )
 		succImplWknStep_att2 : (v : Vect (S predn) ZZ)
 			-> ( vmatQfunc : ( i : Fin _ ) -> (indices i FZ ((v <\> mat)::mat)) `quotientOverZZ` (head $ v <\> mat) )
 			-> (fi : Fin (S predn))
 			-> ( imat : Matrix (S (S predn)) (S predm) ZZ ** ( downAndNotRightOfEntryImpliesZ2 imat (FS fi) FZ, imat `spanslz` (v <\> mat)::mat, (v <\> mat)::mat `spanslz` imat ) )
 			-> ( imat' : Matrix (S (S predn)) (S predm) ZZ ** ( downAndNotRightOfEntryImpliesZ2 imat' (weaken fi) FZ, imat' `spanslz` (v <\> mat)::mat, (v <\> mat)::mat `spanslz` imat' ) )
+		succImplWknStep_att2 senior srQfunc fi imatAndPrs = succImplWknStep_unplumbed senior srQfunc fi (getWitness imatAndPrs) (getProof imatAndPrs)
 		{-
 		Type mismatch between
 		        Vect (S predn) ZZ (Type of v)

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -159,6 +159,15 @@ elimFirstCol mat@((xx::xxs)::xs) = do {
 		let (v ** fn) = runGCDOfVectAlg gcdalg _ (getCol FZ mat)
 
 		{-
+		* We want the first entry of (gexs) to be (v <:> (getCol FZ mat)), and to acquire the full vector as a linear combination of (mat) rows.
+		* index FZ (r<\>m) = r<:>(index FZ $ transpose m) = r<:>(getCol FZ m)
+		* to that end, we begin construction by appending (v<\>mat) to (mat).
+		-}
+
+		let bisWithGCD = the ((v<\>mat)::mat `spanslz` mat, mat `spanslz` (v<\>mat)::mat)
+			(extendSpanningLZsByPreconcatTrivially {zs=[_]} spanslzrefl, mergeSpannedLZs spanslzRowTimesSelf spanslzrefl)
+
+		{-
 		* Use the properties of fn to construct mat', with bar1 and bar2 following by construction and divisibility
 		-}
 
@@ -170,12 +179,11 @@ elimFirstCol mat@((xx::xxs)::xs) = do {
 		> let mat' = Data.Vect.zipWith (\i => \xi => updateAt i (<-> (v <:> (getCol FZ mat))<.>(Sigma.getWitness $ fn i) <#> xi) mat) range mat
 		-}
 
-		let fstcolz_mat' = the (firstColZero mat') ?lemma_fstcolz_mat'
-
 		{-
-		* You want the first entry of (gexs) to be (v <:> (getCol FZ mat)), and to acquire the full vector as linear combination of mat rows.
-		* index FZ (r<\>m) = r<:>(index FZ $ transpose m) = r<:>(getCol FZ m)
+		We could just foldl with (mat ** spanslzrefl) the seed to the accumulator and accumulate by transforming the matrix to a new one and deriving a proof of its (mat) bispannability from the old proof composed with a proof the transformation preserves bispannability. Refining this fold, an accumulation of the evidence required to show that the first column becomes null below the top/gcd row of the matrix (which is invariant under the transformations).
 		-}
+
+		let fstcolz_mat' = the (firstColZero mat') ?lemma_fstcolz_mat'
 
 		-- return ( (v <\> mat)::mat' ** (?bar1,?bar2,fstcolz_mat'))
 		return $ believe_me "shshs"

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -16,6 +16,12 @@ import FinOrdering
 
 
 
+{-
+Properties of vectors and matrices.
+-}
+
+
+
 downAndNotRightOfEntryImpliesZ : (xs : Matrix n m ZZ) -> (row : Fin n) -> (col : Fin m) -> Type
 downAndNotRightOfEntryImpliesZ xs nel mel {n} {m} = {i : Fin n} -> {j : Fin m} -> (finToNat nel `LTRel` finToNat i) -> (finToNat j `LTERel` finToNat mel) -> indices i j xs = Pos Z
 {-
@@ -84,5 +90,19 @@ rowEchelon {n} {m} xs = (narg : Fin n) -> (ty narg)
 			| Right someNonZness with someNonZness
 				| (leadeln ** _) = downAndNotRightOfEntryImpliesZ xs nel leadeln
 			| Left _ = {nelow : Fin n} -> (finToNat nel `LTRel` finToNat nelow) -> index nel xs = neutral
+
+
+
+{-
+Intermediate or secondary algorithms
+-}
+
+
+
+{-
+Main algorithm
+-}
+
+
 
 gaussElimlz : (xs : Matrix n m ZZ) -> (gexs : Matrix n' m ZZ ** (gexs `spanslz` xs, xs `spanslz` gexs, rowEchelon gexs))

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -364,6 +364,7 @@ foldAutoind2 {predn=Z} p regr (v ** pv) = ( [v] ** \i => rewrite sym (the (FZ = 
 foldAutoind2 {predn=S prededn} p regr (v ** pv) with (regr (last {n=prededn}) (v ** pv))
 	| (v' ** pv') with ( foldAutoind2 {predn=prededn} (\mu => (p $ S mu) . weaken) (fai_regrwkn2 p regr) (v' ** pv') )
 		| (xs ** fn) = ?faiNew2
+		-- See commented "proof" for faiNew just above.
 		-- | ( xs ** fn ) = ( xs++[v] ** ?foldAutoind_rhs_2 )
 
 

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -154,7 +154,14 @@ fai_regrwkn : ( p : (m : Nat) -> Fin (S m) -> a -> Type )
 fai_regrwkn p fn i = fn (weaken i)
 
 ||| A vector fold over suppressed indices
-||| Best used with those `p` which are trivial for (last) and some (a).
+|||
+||| Extends one witness for some predicate
+|||
+||| p : (m : Nat) -> Fin (S m) -> a -> Type
+|||
+||| to a (Vect) of them.
+|||
+||| Best used with those (p) which are trivial for (last) and some (a).
 foldAutoind : ( p : (m : Nat) -> Fin (S m) -> a -> Type )
 	-> ( (i : Fin predn)
 		-> ( w : a ** p _ (FS i) w )
@@ -199,7 +206,13 @@ fai2_regrwkn : (a : Nat -> Type)
 fai2_regrwkn a p fn i = fn (weaken i)
 
 ||| A vector fold over suppressed indices
-||| The sequel to foldAutoind
+|||
+||| Same strength of result as foldAutoind, but where the predicate is of the form
+|||
+||| p : (m : Nat) -> Fin (S m) -> (a m) -> Type
+|||
+||| for when it isn't naturally expressed or proved without affecting
+||| the type (a _) of the witnesses dealt with by this process.
 {-
 (a : Nat -> Type) is not made implicit because Idris isn't likely to deduce it and will likely spend a long time trying anyway.
 -}

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -144,6 +144,7 @@ elimFirstCol ([]::xs) = ?elimFirstCol_widthZero
 elimFirstCol mat@((xx::xxs)::xs) = do {
 		gcdalg <- ask @{the (MonadReader gcdOfVectAlg _) %instance}
 		{-
+
 		Error:
 
 		> elimFirstCol (x::xs) {m} = do {
@@ -152,13 +153,31 @@ elimFirstCol mat@((xx::xxs)::xs) = do {
 		>	-- which is a ( v : Vect _ ZZ ** ( i : Fin k ) -> (index i x) `quotientOverZZ` (v <:> x) )
 
 			gcdalg does not have a function type (gcdOfVectAlg)
+
 		-}
 		-- (v ** fn) : ( v : Vect _ ZZ ** ( i : Fin _ ) -> (index i matcolZ) `quotientOverZZ` (v <:> matcolZ) )
 		let (v ** fn) = runGCDOfVectAlg gcdalg _ (getCol FZ mat)
-		-- claim mat' typeOf mat
-		-- claim fstcolz_mat' firstColZero mat'
-		--	to use the properties of fn to construct, with bar1 and bar2 following by construction and divisibility
-		-- return ( (v <:> (getCol FZ mat))::mat' ** (?bar1,?bar2,fstcolz_mat'))
+		{-
+
+		* Use the properties of fn to construct mat', with bar1 and bar2 following by construction and divisibility
+
+		-}
+		let mat' = mat <-> (map (\i => (v <:> (getCol FZ mat))<.>(Sigma.getWitness $ fn i) <#> (index i mat)) range)
+		{-
+
+		Typechecks, but we'll try the above for now
+
+		> let mat' = Data.Vect.zipWith (\i => \xi => updateAt i (<-> (v <:> (getCol FZ mat))<.>(Sigma.getWitness $ fn i) <#> xi) mat) range mat
+
+		-}
+		let fstcolz_mat' = the (firstColZero mat') ?lemma_fstcolz_mat'
+		{-
+
+		* You want the first entry of (gexs) to be (v <:> (getCol FZ mat)), and to acquire the full vector as linear combination of mat rows.
+		* index FZ (r<\>m) = r<:>(index FZ $ transpose m) = r<:>(getCol FZ m)
+
+		-}
+		-- return ( (v <\> mat)::mat' ** (?bar1,?bar2,fstcolz_mat'))
 		return $ believe_me "shshs"
 	}
 

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -206,7 +206,7 @@ elimFirstCol mat@((xx::xxs)::xs) {n=S predn} {m=S predm} = do {
 			( (v<\>mat)::mat ** (spanslzrefl,spanslzrefl,(FZ ** ?proveItAbs)) ) range
 		-- proveItAbs is like \j => void . ( spawnNotLTE (finToNat (FS j)) (finToNat FZ)) )
 		-- spawnNotLTE is an explicit (LTERel _ _ -> Void) to be proved, avoiding any (decLTE) (Yes/No)-case handling problems.
-		-- f should take its argument (elt:=Fin (S predn)) to its successor so it can be used to index (imat) and so that it will always be non-FZ and thus never using the same (Fin (S (S predn))) as the base case has.
+		-- f should take its argument (elt:=Fin (S predn)) to its successor so it can be used to index (imat), starting in its tail, and so that it will always be non-FZ and thus never using the same (Fin (S (S predn))) as the base case has.
 
 		{-
 		We need to show that for every row (i) of (mat), there is a vector (u) such that (u_(FS i)<\>(droprow (FS i) (v<\>mat)::mat) has the same value as row (i) of (mat) at column FZ). Especially that this property is preserved in each (imat).

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -103,12 +103,29 @@ Intermediate or secondary algorithms
 
 
 
+-- Should be modified to account for (gcd x 0 = 0).
 quotientOverZZ : ZZ -> ZZ -> Type
 quotientOverZZ x y = ( d : ZZ ** d<.>y=x )
 
 -- Making argument "k" implicit will not work.
 gcdOfVectAlg : Type
 gcdOfVectAlg = (k : Nat) -> (x : Vect k ZZ) -> ( v : Vect k ZZ ** ( i : Fin k ) -> (index i x) `quotientOverZZ` (v <:> x) )
+
+firstColZero : (xs : Matrix n m ZZ) -> Type
+firstColZero [] = ()
+firstColZero ([]::xs) = ()
+firstColZero ((xx::xxs)::xs) = (xx=neutral, firstColZero xs)
+
+firstColZeroCalc : (xs : Matrix n m ZZ) -> Dec $ firstColZero xs
+firstColZeroCalc [] = Yes ()
+firstColZeroCalc ([]::xs) = Yes ()
+firstColZeroCalc ((xx::xxs)::xs) with (firstColZeroCalc xs)
+	| No pr = No ( pr . snd )
+	| Yes pr with (decEq xx neutral)
+		| Yes isneut = Yes (isneut, pr)
+		| No nope = No ( nope . fst )
+
+elimFirstCol : Reader gcdOfVectAlg ( (xs : Matrix n m ZZ) -> (gexs : Matrix (S predn') m ZZ ** (gexs `spanslz` xs, xs `spanslz` gexs, firstColZero $ tail gexs)) )
 
 gaussElimlzIfGCD : Reader gcdOfVectAlg ( (xs : Matrix n m ZZ) -> (gexs : Matrix n' m ZZ ** (gexs `spanslz` xs, xs `spanslz` gexs, rowEchelon gexs)) )
 

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -206,6 +206,7 @@ elimFirstCol mat@((xx::xxs)::xs) {n=S predn} {m=S predm} = do {
 			( (v<\>mat)::mat ** (spanslzrefl,spanslzrefl,(FZ ** ?proveItAbs)) ) range
 		-- proveItAbs is like \j => void . ( spawnNotLTE (finToNat (FS j)) (finToNat FZ)) )
 		-- spawnNotLTE is an explicit (LTERel _ _ -> Void) to be proved, avoiding any (decLTE) (Yes/No)-case handling problems.
+		-- f should take its argument (elt:=Fin (S predn)) to its successor so it can be used to index (imat) and so that it will always be non-FZ and thus never using the same (Fin (S (S predn))) as the base case has.
 
 		{-
 		We need to show that for every row (i) of (mat), there is a vector (u) such that (u_(FS i)<\>(droprow (FS i) (v<\>mat)::mat) has the same value as row (i) of (mat) at column FZ). Especially that this property is preserved in each (imat).

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -8,6 +8,8 @@ import Data.Matrix
 import Data.Matrix.Algebraic -- module instances; from Idris 0.9.20
 import Data.Matrix.AlgebraicVerified
 
+import Data.Vect.Structural
+
 import Data.ZZ
 import Control.Algebra.NumericInstances
 import Control.Algebra.ZZVerifiedInstances
@@ -70,7 +72,7 @@ ringVecNeutralIsVecPtwiseProdZeroR : VerifiedRing a => (xs : Vect n a) -> (the (
 ringVecNeutralIsVecPtwiseProdZeroR [] {a} = Refl
 ringVecNeutralIsVecPtwiseProdZeroR (x::xs) = vecHeadtailsEq (ringNeutralIsMultZeroR x) $ ringVecNeutralIsVecPtwiseProdZeroR xs
 
-vecMatMultTransposeEq : Ring a => (v : Vect n a) -> (xs : Matrix n m a) -> v <\> xs = (transpose xs) </> v
+matVecMultIsVecTransposeMult : Ring a => (v : Vect n a) -> (xs : Matrix n m a) -> v <\> xs = (transpose xs) </> v
 
 ringVecNeutralIsMatVecMultZero : VerifiedRing a => (xs : Matrix n m a) -> xs </> Algebra.neutral = Algebra.neutral
 ringVecNeutralIsMatVecMultZero [] = Refl
@@ -93,15 +95,6 @@ vecMatMultIsTransposeVecMult v xs = Refl
 
 matVecMultIsVecTransposeMult : Ring a => (v : Vect m a) -> (xs : Matrix n m a) -> xs </> v = v <\> (transpose xs)
 matVecMultIsVecTransposeMult v xs = sym $ trans (vecMatMultIsTransposeVecMult v $ transpose xs) $ cong {f=(</> v)} $ transposeIsInvolution {xs=xs}
-
-{-
-zzVecNeutralIsMatVecMultZero : (xs : Matrix n m ZZ) -> xs </> Algebra.neutral = Algebra.neutral
-zzVecNeutralIsMatVecMultZero [] = Refl
-zzVecNeutralIsMatVecMultZero (x::xs) = vecHeadtailsEq (zzVecNeutralIsVecPtwiseProdZeroL x) $ zzVecNeutralIsMatVecMultZero xs
-
-zzVecNeutralIsVecMatMultZero : (xs : Matrix n m ZZ) -> Algebra.neutral <\> xs = Algebra.neutral
-zzVecNeutralIsVecMatMultZero xs = trans (vecMatMultIsTransposeVecMult Algebra.neutral xs) $ zzVecNeutralIsMatVecMultZero $ transpose xs
--}
 
 zzVecNeutralIsVecMatMultZero : (xs : Matrix n m ZZ) -> Algebra.neutral <\> xs = Algebra.neutral
 zzVecNeutralIsVecMatMultZero xs {m=Z} = zeroVecEq
@@ -580,55 +573,6 @@ foldAutoind3 {predn=Z} _ p regr (v ** pv) = ( [v] ** \i => rewrite sym (the (FZ 
 foldAutoind3 {predn=S prededn} natToA p regr (v ** pv) with (regr (last {n=prededn}) (v ** pv))
 	-- Compare with the corresponding (outer) with block in foldAutoind2
 	| (v' ** pv') = ?fai3_induceMe
-
-
-
-indexMapChariz : Data.Vect.index k $ map f xs = f $ index k xs
-indexMapChariz {xs=[]} {k} = FinZElim k
--- indexMapChariz {xs} {f} {k=FZ} = trans indexFZIsheadValued $ trans headMapChariz $ sym $ cong indexFZIsheadValued
-indexMapChariz {xs=x::xs} {f} {k=FZ} = Refl
-indexMapChariz {xs=x::xs} {f} {k=FS k} = indexMapChariz {xs=xs} {f=f} {k=k}
-
-indexUpdateAtChariz : index i $ updateAt i f xs = f $ index i xs
-indexUpdateAtChariz {xs=[]} {i} = FinZElim i
-indexUpdateAtChariz {xs=(x::xs)} {f} {i=FZ} = Refl
-indexUpdateAtChariz {xs=x::xs} {f} {i=FS i} = indexUpdateAtChariz {xs=xs} {f=f} {i=i}
-
-updateAtIndIsMapAtInd : index i $ updateAt i f xs = index i $ map f xs
-updateAtIndIsMapAtInd = trans indexUpdateAtChariz $ sym indexMapChariz
-
-deleteSuccRowVanishesUnderHead : head $ deleteRow (FS k) xs = head xs
-deleteSuccRowVanishesUnderHead {xs=x::xs} = Refl
-
-updateAtSuccRowVanishesUnderHead : head $ updateAt (FS k) f xs = head xs
-updateAtSuccRowVanishesUnderHead {xs=x::xs} = Refl
-
-
-
-zipWithEntryChariz : index i $ Vect.zipWith m x y = m (index i x) (index i y)
-
-
-
--- For completeness's sake, these should have (index FZ) as (head) forms proved.
-
-indexCompatInverse : VerifiedRingWithUnity a => (xs : Vect n a) -> (i : Fin n) -> index i $ inverse xs = inverse $ index i xs
-
-indexCompatAdd : VerifiedRingWithUnity a => (xs, ys : Vect n a) -> (i : Fin n) -> index i $ xs <+> ys = index i xs <+> index i ys
-indexCompatAdd xs ys i = zipWithEntryChariz {x=xs} {y=ys} {i=i} {m=(<+>)}
-
-{-
-Proof obstruction seems to be that the meaning of "inverse" depends on whether the class hierarchy is treated as
-
-	VerifiedGroup < Group < Monoid < Semigroup
-
-or as
-
-	VerifiedGroup < VerifiedMonoid < VerifiedSemigroup < Semigroup
--}
-indexCompatSub : VerifiedRingWithUnity a => (xs, ys : Vect n a) -> (i : Fin n) -> index i $ xs <-> ys = index i xs <-> index i ys
-indexCompatSub xs ys i ?= trans (indexCompatAdd xs (inverse ys) i) $ cong {f=((index i xs)<+>)} $ indexCompatInverse ys i
-
-indexCompatScaling : VerifiedRingWithUnity a => (r : a) -> (xs : Vect n a) -> (i : Fin n) -> index i $ r <#> xs = r <.> index i xs
 
 
 

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -1092,31 +1092,10 @@ elimFirstCol mat {n=S predn} {m=S predm} = do {
 
 
 
-succImplWknProp : {omat : Matrix onnom (S predm) ZZ} -> (nu : Nat) -> (fi : Fin (S nu)) -> Matrix (S nu) (S predm) ZZ -> Type
-succImplWknProp {omat} nu fi tmat = ( tmat `spanslz` omat, omat `spanslz` tmat, downAndNotRightOfEntryImpliesZ tmat fi FZ )
-succImplWknPropSec3 : {omat : Matrix onnom (S predm) ZZ} -> (nu : Nat) -> (fi : Fin (S nu)) -> Matrix (S nu) (S predm) ZZ -> Type
-succImplWknPropSec3 {omat} nu fi tmat = downAndNotRightOfEntryImpliesZ tmat fi FZ
-
-succImplWknProp2 : (omat : Matrix onnom (S predm) ZZ) -> (nu : Nat) -> (fi : Fin (S nu)) -> Matrix (S nu) (S predm) ZZ -> Type
-succImplWknProp2 omat nu fi tmat = ( downAndNotRightOfEntryImpliesZ2 tmat fi FZ, tmat `spanslz` omat, omat `spanslz` tmat )
-succImplWknProp2Sec1 : (omat : Matrix onnom (S predm) ZZ) -> (nu : Nat) -> (fi : Fin (S nu)) -> Matrix (S nu) (S predm) ZZ -> Type
-succImplWknProp2Sec1 omat nu fi tmat = downAndNotRightOfEntryImpliesZ2 tmat fi FZ
-
 succImplWknProp3 : (omat : Matrix predonnom (S predm) ZZ) -> (senior : Vect (S predm) ZZ) -> (nu : Nat) -> (fi : Fin (S nu)) -> Matrix (S nu) (S predm) ZZ -> Type
 succImplWknProp3 omat senior nu fi tmat = ( senior = head tmat, downAndNotRightOfEntryImpliesZ2 tmat fi FZ, tmat `bispanslz` (senior::omat) )
 succImplWknProp3Sec2 : (nu : Nat) -> (fi : Fin (S nu)) -> Matrix (S nu) (S predm) ZZ -> Type
 succImplWknProp3Sec2 nu fi tmat = downAndNotRightOfEntryImpliesZ2 tmat fi FZ
-
-{-
-danrzLast : {omat : Matrix (S (S predn)) (S predm) ZZ} -> succImplWknPropSec3 {omat=omat} (S predn) (last {n=S predn}) omat
-danrzLast = void . notSNatLastLTEAnything
--}
-
-danrzLast : {omat : Matrix (S predn) (S predm) ZZ} -> succImplWknPropSec3 {omat=omat} predn (last {n=predn}) omat
-danrzLast = void . notSNatLastLTEAnything
-
-danrzLast2 : (omat : Matrix (S predn) (S predm) ZZ) -> succImplWknProp2Sec1 omat predn (last {n=predn}) omat
-danrzLast2 omat = (\i => \j => void . notSNatLastLTEAnything)
 
 danrzLast3 : (omat : Matrix (S predn) (S predm) ZZ) -> succImplWknProp3Sec2 predn (last {n=predn}) omat
 danrzLast3 omat = (\i => \j => void . notSNatLastLTEAnything)
@@ -1156,6 +1135,9 @@ elimFirstCol2 mat {n=S predn} {predm} = do {
 			(extendSpanningLZsByPreconcatTrivially {zs=[_]} spanslzrefl, mergeSpannedLZs spanslzRowTimesSelf spanslzrefl)
 
 		{-
+		!!! ARCHAICLY WRITTEN COMMENT.
+		!!! At the time, foldedFully had a different type, and some of the types had different values, compared to what currently exists.
+
 		The error here is indecipherable from the message. See the form below for an improvement.
 		---
 		let ( endmat ** endmatPropFn ) = foldAutoind2 (succImplWknProp {omat=(v <\> mat)::mat}) (succImplWknStep {v=v}) ( (v<\>mat)::mat ** (spanslzrefl, spanslzrefl, the ( downAndNotRightOfEntryImpliesZ ((v<\>mat)::mat) (last {n=predn}) FZ ) $ void . notSNatLastLTEAnything) )
@@ -1171,38 +1153,25 @@ elimFirstCol2 mat {n=S predn} {predm} = do {
 		let ( endmat ** endmatPropFn ) = foldAutoind2 (succImplWknProp {omat=(v <\> mat)::mat}) (succImplWknStep {v=v}) ( (v<\>mat)::mat ** (spanslzrefl, spanslzrefl, danrzLast {omat=(v <\> mat)::mat}) )
 		-}
 
-		let ( endmat ** endmatPropFn ) = foldedFully {v=v}
-
-		let ( endmatSpansMatandgcd, matandgcdSpansEndmat, leftColZBelow ) = endmatPropFn FZ
-
 		let ( endmat2 ** endmat2PropFn ) = foldedFully_att3 v ?vQfunc
 
 		let ( headvecWasFixed, leftColZBelow2, endmat2BispansMatandgcd ) = endmat2PropFn FZ
 
 		return ( index FZ endmat2 ** (leftColZBelow2, bispanslztrans endmat2BispansMatandgcd bisWithGCD) )
-		-- return ( index FZ endmat ** (spanslztrans endmatSpansMatandgcd $ fst bisWithGCD, spanslztrans (snd bisWithGCD) matandgcdSpansEndmat, leftColZBelow) )
 	}
 	where
 		{-
-		!!! This (succImplWknStep) is dead code, retained for (foldedFully).
-		!!! See (succImplWknStep_att2) and (foldedFully_att2) for living code.
-		-}
-		succImplWknStep : {v : Vect (S predn) ZZ}
-			-> (fi : Fin (S predn))
-			-> ( imat : Matrix (S (S predn)) (S predm) ZZ ** ( imat `spanslz` (v <\> mat)::mat, (v <\> mat)::mat `spanslz` imat, downAndNotRightOfEntryImpliesZ imat (FS fi) FZ ) )
-			-> ( imat' : Matrix (S (S predn)) (S predm) ZZ ** ( imat' `spanslz` (v <\> mat)::mat, (v <\> mat)::mat `spanslz` imat', downAndNotRightOfEntryImpliesZ imat' (weaken fi) FZ ) )
-		{-
-		Section notes for succImplWknStep_att2
+		Section notes for succImplWknStep_att3
 
 		---
 
 		Structure:
-		lemma3 => lemma2 => lemma1 => succImplWknStep_att2 => foldedFully_att2
+		lemma3 => lemma2 => modded => succImplWknStep => foldedFully
 		(incomplete picture)
 
 		---
 
-		We have learned of two obstructions to expressing (succImplWknStep_att2) and its lemmas which must be taken into account in this design.
+		We have learned of two obstructions to expressing (succImplWknStep_att3) and its lemmas which must be taken into account in this design.
 
 		1) If a dependent pair's proof's type is a function of the witness and has implicit arguments, that dependent pair will not be inferred correctly when used as an argument to a function, and this might only be revealed through type errors in (the left-hand side of) other definitions that are attempted within the function, such as in its where block, where such definitions have the arguments to the function in their assumptions/context (environment, scope).
 
@@ -1210,7 +1179,7 @@ elimFirstCol2 mat {n=S predn} {predm} = do {
 
 			Implementing (foldAutoInd) created a similar problem when using type-valued functions that took certain implicit arguments, which led to writing (foldAutoInd[2-3]) instead. However, the values of those type-valued functions did not clearly have implicit arguments.
 
-		2) A triple of types in the righthand value of a dependent pair is not treated as a type when pattern matching on it, giving type errors when anything is done with the proof (getProof _) except using it as an argument to a function. Hence to get a function from dependent pairs to dependent pairs that applies the theorem proved, we must call a dependently typed but curried version of the function on the witness and proof of the dependent pair input. Whence (succImplWknStep_unplumbed) and the definition of (succImplWknStep) in terms of it.
+		2) A triple of types in the righthand value of a dependent pair is not treated as a type when pattern matching on it, giving type errors when anything is done with the proof (getProof _) except using it as an argument to a function. Hence to get a function from dependent pairs to dependent pairs that applies the theorem proved, we must call a dependently typed but curried version of the function on the witness and proof of the dependent pair input. Whence (succImplWknStep_modded_att2) and the definition of (succImplWknStep_att3) in terms of it.
 
 			Note, we may write (the Type (Nat,Nat,Nat)), but using a predefined (Type) whose value is a triple does not get around the mismatch error.
 		-}
@@ -1284,24 +1253,32 @@ elimFirstCol2 mat {n=S predn} {predm} = do {
 					$ deleteSuccRowVanishesUnderHead {k=fi} {xs=imat}
 				jmatBispansOrig : jmat `bispanslz` (senior::mat)
 				jmatBispansOrig = bispanslztrans (bispanslzreflFromEq {xs=jmat} $ cong {f=\z => updateAt (FS fi) (<-> z) imat} $ trans ( cong {f=((<#>) {a=ZZ} _)} $ trans seniorIsImatHead $ missingstep ) $ sym $ vectMatLScalingCompatibility {z=Sigma.getWitness $ fn $ FS fi} {la=Algebra.unity::Algebra.neutral} {rs=deleteRow (FS fi) imat}) $ bispanslztrans ( bispanslzSubtractiveExchangeAt (FS fi) {xs=imat} {z=(Sigma.getWitness $ fn (FS fi))<#>(Algebra.unity::Algebra.neutral)} ) $ (imatSpansOrig, origSpansImat)
-		succImplWknStep_unplumbed : (v : Vect (S predn) ZZ)
-			-> ( vmatQfunc : ( i : Fin _ ) -> (indices i FZ ((v <\> mat)::mat)) `quotientOverZZ` (head $ v <\> mat) )
-			-> (fi : Fin (S predn))
-			-> ( imat : Matrix (S (S predn)) (S predm) ZZ )
-			-> ( downAndNotRightOfEntryImpliesZ2 imat (FS fi) FZ, imat `spanslz` (v <\> mat)::mat, (v <\> mat)::mat `spanslz` imat )
-			-> ( imat' : Matrix (S (S predn)) (S predm) ZZ ** ( downAndNotRightOfEntryImpliesZ2 imat' (weaken fi) FZ, imat' `spanslz` (v <\> mat)::mat, (v <\> mat)::mat `spanslz` imat' ) )
-		succImplWknStep_att2 : (v : Vect (S predn) ZZ)
-			-> ( vmatQfunc : ( i : Fin _ ) -> (indices i FZ ((v <\> mat)::mat)) `quotientOverZZ` (head $ v <\> mat) )
-			-> (fi : Fin (S predn))
-			-> ( imat : Matrix (S (S predn)) (S predm) ZZ ** ( downAndNotRightOfEntryImpliesZ2 imat (FS fi) FZ, imat `spanslz` (v <\> mat)::mat, (v <\> mat)::mat `spanslz` imat ) )
-			-> ( imat' : Matrix (S (S predn)) (S predm) ZZ ** ( downAndNotRightOfEntryImpliesZ2 imat' (weaken fi) FZ, imat' `spanslz` (v <\> mat)::mat, (v <\> mat)::mat `spanslz` imat' ) )
-		succImplWknStep_att2 senior srQfunc fi imatAndPrs = succImplWknStep_unplumbed senior srQfunc fi (getWitness imatAndPrs) (getProof imatAndPrs)
 		succImplWknStep_att3 : ( senior : Vect (S predm) ZZ ) -> ( srQfunc : ( i : Fin _ ) -> (indices i FZ (senior::mat)) `quotientOverZZ` (head senior) )
 			-> (fi : Fin (S predn))
 			-> ( imat : Matrix (S (S predn)) (S predm) ZZ ** ( senior = head imat, downAndNotRightOfEntryImpliesZ2 {n=S $ S predn} {m=S predm} imat (FS fi) FZ, imat `spanslz` (senior::mat), (senior::mat) `spanslz` imat ) )
 			-> ( imat' : Matrix (S (S predn)) (S predm) ZZ ** ( senior = head imat', downAndNotRightOfEntryImpliesZ2 {n=S $ S predn} {m=S predm} imat' (weaken fi) FZ, imat' `spanslz` (senior::mat), (senior::mat) `spanslz` imat' ) )
 		succImplWknStep_att3 senior srQfunc fi imatAndPrs = succImplWknStep_modded_att2 senior srQfunc fi (getWitness imatAndPrs) (getProof imatAndPrs)
 		{-
+		Misleading error message from using name in type signature before it enters scope.
+
+		---
+
+		If you write
+
+		> succImplWknStep_att3 : ( senior : Vect (S predm) ZZ ) -> ( srQfunc : ( i : Fin _ ) -> (indices i FZ (senior::mat)) `quotientOverZZ` (head senior) )
+		> 	-> (fi : Fin (S predn))
+		> 	-> ( imat : Matrix (S (S predn)) (S predm) ZZ ** ( senior = head imat, downAndNotRightOfEntryImpliesZ2 {n=S $ S predn} {m=S predm} imat (FS fi) FZ, imat' `spanslz` (senior::mat), (senior::mat) `spanslz` imat ) )
+		> 	-> ( imat' : Matrix (S (S predn)) (S predm) ZZ ** ( senior = head imat', downAndNotRightOfEntryImpliesZ2 {n=S $ S predn} {m=S predm} imat' (weaken fi) FZ, imat' `spanslz` (senior::mat), (senior::mat) `spanslz` imat' ) )
+
+		then on the 3rd line near the end, you see "imat'" when (imat') has not been defined yet, and it should read "imat".
+
+		1) This creates a host of error messages saying they're from (foldedFully3_att3) when they're actually from (succImplWknStep_att3).
+		2) The error messages are misleading. In particular, it seems to say that one of the matrices must, whatever its height and width, have that width for its height and that height for its width.
+		3) Using a (with (succImplWknStep_att3 ...)) or (let (x = succImplWknStep_att3 ...)) block in the definition of (foldedFully_att3) is enough to trigger the error.
+
+		One such error message:
+
+		"
 		Type mismatch between
 		        Vect (S predn) ZZ (Type of v)
 		and
@@ -1312,40 +1289,10 @@ elimFirstCol2 mat {n=S predn} {predm} = do {
 		                predn
 		        and
 		                predm
+		"
 
-		> foldedFully {v} = foldAutoind3 {predn=S predn} (\ne => Matrix (S ne) (S predm) ZZ) (succImplWknProp {omat=(v <\> mat)::mat}) (succImplWknStep {v=v}) ( (v<\>mat)::mat ** (spanslzrefl, spanslzrefl, danrzLast {omat=(v <\> mat)::mat}) )
-
-		similarly for
-
-		> foldedFully {v} with ( succImplWknStep {v=v} )
-		> 	| fonc = ?foldedFully_pr
-
-		or (what you'd actually have to write)
-
-		> foldedFully {v} = let fonc = succImplWknStep {v=v} in ?foldedFully_pr
-
-		but then we can change the error with
-
-		foldedFully {v} with ( succImplWknStep )
-			| fonc = ?foldedFully_pr
-
-		to see the type of (mat) is mismatching an expected type the transpose.
-
-		First error was here:
-		
-		> succImplWknStep : {v : Vect (S predn) ZZ}
-		> 	-> (fi : Fin (S predn))
-		> 	-> ( imat : Matrix (S (S predn)) (S predm) ZZ ** ( imat `spanslz` (v <\> mat)::mat, (v <\> mat)::mat `spanslz` imat, downAndNotRightOfEntryImpliesZ imat' (FS fi) FZ ) )
-		> 	-> ( imat' : Matrix (S (S predn)) (S predm) ZZ ** ( imat' `spanslz` (v <\> mat)::mat, (v <\> mat)::mat `spanslz` imat', downAndNotRightOfEntryImpliesZ imat' (weaken fi) FZ ) )
-
-		where on the third line at the very end, (imat') is referenced but doesn't exist yet.
+		A similar one was found indicating a type mismatch between (Matrix (S predn) (S predm) ZZ) and (Matrix (S predm) (S predn) ZZ), where both the argument chosen and the function's assigned type for that argument were equal to (Matrix (S predn) (S predm) ZZ).
 		-}
-		foldedFully : {v : Vect (S predn) ZZ} -> ( mats : Vect (S (S predn)) $ Matrix (S (S predn)) (S predm) ZZ ** (i : Fin (S (S predn))) -> succImplWknProp {omat=(v<\>mat)::mat} (S predn) i (index i mats) )
-		foldedFully {v} = foldAutoind3 {predn=S predn} (\ne => Matrix (S ne) (S predm) ZZ) (succImplWknProp {omat=(v <\> mat)::mat}) (succImplWknStep {v=v}) ( (v<\>mat)::mat ** (spanslzrefl, spanslzrefl, danrzLast {omat=(v <\> mat)::mat}) )
-		foldedFully_att2 : (v : Vect (S predn) ZZ)
-			-> ( vmatQfunc : ( i : Fin _ ) -> (indices i FZ ((v <\> mat)::mat)) `quotientOverZZ` (head $ v <\> mat) )
-			-> ( mats : Vect (S (S predn)) $ Matrix (S (S predn)) (S predm) ZZ ** (i : Fin (S (S predn))) -> succImplWknProp2 ((v<\>mat)::mat) (S predn) i (index i mats) )
-		foldedFully_att2 v vmatQfunc = foldAutoind3 {predn=S predn} (\ne => Matrix (S ne) (S predm) ZZ) (succImplWknProp2 ((v <\> mat)::mat)) (succImplWknStep_att2 v vmatQfunc) ( (v<\>mat)::mat ** (danrzLast2 ((v <\> mat)::mat), spanslzrefl, spanslzrefl) )
 		foldedFully_att3 : (v : Vect (S predn) ZZ)
 			-> ( vmatQfunc : ( i : Fin _ ) -> (indices i FZ ((v <\> mat)::mat)) `quotientOverZZ` (head $ v <\> mat) )
 			-> ( mats : Vect (S (S predn)) $ Matrix (S (S predn)) (S predm) ZZ ** (i : Fin (S (S predn))) -> succImplWknProp3 mat (v<\>mat) (S predn) i (index i mats) )

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -289,6 +289,8 @@ fai_regrwkn2 : ( p : (m : Nat) -> Fin (S m) -> a -> Type )
 	-> (i : Fin predn)
 	-> ( w : a ** ((p _) . weaken) (FS i) w )
 	-> ( w' : a ** ((p _) . weaken) (weaken i) w' )
+-- can't be written as `(fn . weaken) i`, nor can `i` be dropped as an argument.
+fai_regrwkn2 p fn i = fn (weaken i)
 
 
 

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -143,8 +143,8 @@ elimFirstCol [] {m} {predn'=Z} = return (row {n=m} neutral ** ( ([] ** Refl), ([
 elimFirstCol ([]::xs) = ?elimFirstCol_widthZero
 elimFirstCol mat@((xx::xxs)::xs) = do {
 		gcdalg <- ask @{the (MonadReader gcdOfVectAlg _) %instance}
-		{-
 
+		{-
 		Error:
 
 		> elimFirstCol (x::xs) {m} = do {
@@ -153,30 +153,30 @@ elimFirstCol mat@((xx::xxs)::xs) = do {
 		>	-- which is a ( v : Vect _ ZZ ** ( i : Fin k ) -> (index i x) `quotientOverZZ` (v <:> x) )
 
 			gcdalg does not have a function type (gcdOfVectAlg)
-
 		-}
+
 		-- (v ** fn) : ( v : Vect _ ZZ ** ( i : Fin _ ) -> (index i matcolZ) `quotientOverZZ` (v <:> matcolZ) )
 		let (v ** fn) = runGCDOfVectAlg gcdalg _ (getCol FZ mat)
-		{-
 
+		{-
 		* Use the properties of fn to construct mat', with bar1 and bar2 following by construction and divisibility
-
 		-}
-		let mat' = mat <-> (map (\i => (v <:> (getCol FZ mat))<.>(Sigma.getWitness $ fn i) <#> (index i mat)) range)
-		{-
 
+		let mat' = mat <-> (map (\i => (v <:> (getCol FZ mat))<.>(Sigma.getWitness $ fn i) <#> (index i mat)) range)
+
+		{-
 		Typechecks, but we'll try the above for now
 
 		> let mat' = Data.Vect.zipWith (\i => \xi => updateAt i (<-> (v <:> (getCol FZ mat))<.>(Sigma.getWitness $ fn i) <#> xi) mat) range mat
-
 		-}
-		let fstcolz_mat' = the (firstColZero mat') ?lemma_fstcolz_mat'
-		{-
 
+		let fstcolz_mat' = the (firstColZero mat') ?lemma_fstcolz_mat'
+
+		{-
 		* You want the first entry of (gexs) to be (v <:> (getCol FZ mat)), and to acquire the full vector as linear combination of mat rows.
 		* index FZ (r<\>m) = r<:>(index FZ $ transpose m) = r<:>(getCol FZ m)
-
 		-}
+
 		-- return ( (v <\> mat)::mat' ** (?bar1,?bar2,fstcolz_mat'))
 		return $ believe_me "shshs"
 	}

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -695,12 +695,46 @@ elimFirstCol mat {n=S predn} {m=S predm} = do {
 			) )
 -}
 
+
+
 {-
 Better to refine this to a type that depends on (m=S predm) so that the case (m=Z) may also be covered.
 
 Shall start from the bottom of the matrix (last) and work up to row (FS FZ) using a traversal based on (weaken) and a binary map from index (Fin n) and oldvals to newvals.
 -}
+
 elimFirstCol2 : (xs : Matrix n (S predm) ZZ) -> Reader ZZGaussianElimination.gcdOfVectAlg (gexs : Matrix (S n) (S predm) ZZ ** (gexs `spanslz` xs, xs `spanslz` gexs, downAndNotRightOfEntryImpliesZ gexs FZ FZ))
+{-
+-- Template
+
+elimFirstCol2 xs = do {
+		gcdalg <- ask @{the (MonadReader ZZGaussianElimination.gcdOfVectAlg _) %instance}
+		return $ believe_me "Weiell"
+	}
+-}
+
+elimFirstCol2 [] {predm} = return ( row {n=S predm} $ neutral ** ( ([] ** Refl), ([neutral] ** Refl), nosuch ) )
+	where
+		nosuch : LTRel Z (finToNat i)
+			-> LTERel (finToNat j) Z
+			-> indices i j (row {n=S predm} Prelude.Algebra.neutral) = Pos 0
+		nosuch {i=FZ} {j=FZ} _ = either (const Refl) (const Refl)
+		nosuch {i=FS k} {j=FZ} _ = absurd k
+		nosuch {j=FS k} _ = void . ( either succNotLTEzero SIsNotZ )
+{-
+elimFirstCol2 mat {n=S predn} {predm} = do {
+		gcdalg <- ask @{the (MonadReader ZZGaussianElimination.gcdOfVectAlg _) %instance}
+		return $ believe_me "Weiell"
+	}
+-}
+
+{-
+Reference
+---
+We're using
+
+foldAutoind2
+-}
 
 {-
 gcdOfVectAlg = (k : Nat) -> (x : Vect k ZZ) -> ( v : Vect k ZZ ** ( i : Fin k ) -> (index i x) `quotientOverZZ` (v <:> x) )

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -264,31 +264,11 @@ elimFirstCol mat {n=S predn} {m=S predm} = do {
 -}
 
 {-
-( updateAt (FS fi) (<->(?makesXXTheHeadMatHeadless<\>(deleteRow (FS fi) imat))) imat ** (spanslztrans imatSpansMatandgcd (spanslzSubtractiveExchangeAt $ FS fi), spanslztrans (?spanslzSubtractivePreservationAt $ FS fi) matandgcdSpansImat, (FS fi ** ?extendedFunc))
--}
+Better to refine this to a type that depends on (m=S predm) so that the case (m=Z) may also be covered.
 
-{-
-let foldSomefuncPreservingBispan2 = \f => foldl
-	{t=Vect (S predn)}
-	{elt=Fin (S predn)}
-	{acc=( imat : Matrix (S (S predn)) (S predm) ZZ **
-		( imat `spanslz` (v <\> mat)::mat,
-		(v <\> mat)::mat `spanslz` imat,
-		(i : Fin (S predn) ** {j : Fin (S predn)}
-			-> finToNat j `LTERel` finToNat i
-			-> indices j FZ (tail imat) = Pos Z)
-		)
-	)}
-	f
- 	( updateAt (FS FZ)
-		(<->(?makesXXTheHeadMatHeadless<\>(deleteRow (FS FZ) (v<\>mat)::mat)))
-		(v<\>mat)::mat
-		** (spanslzSubtractiveExchangeAt FS FZ,
-			?howel,
-			(FZ ** ?initTheFirstRowOfTailIsZero)
-		)
-	) (map FS range)
+Shall start from the bottom of the matrix (last) and work up to row (FS FZ) using a traversal based on (weaken) and a binary map from index (Fin n) and oldvals to newvals.
 -}
+elimFirstCol2 : (xs : Matrix n (S predm) ZZ) -> Reader ZZGaussianElimination.gcdOfVectAlg (gexs : Matrix (S n) (S predm) ZZ ** (gexs `spanslz` xs, xs `spanslz` gexs, downAndNotRightOfEntryImpliesZ gexs FZ FZ))
 
 {-
 gcdOfVectAlg = (k : Nat) -> (x : Vect k ZZ) -> ( v : Vect k ZZ ** ( i : Fin k ) -> (index i x) `quotientOverZZ` (v <:> x) )

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -14,6 +14,10 @@ import ZZModuleSpan
 
 import FinOrdering
 
+-- For style. ((Reader r a) equivalent to (r -> a))
+import Control.Monad.Identity
+import Control.Monad.Reader
+
 
 
 {-
@@ -102,9 +106,21 @@ Intermediate or secondary algorithms
 quotientOverZZ : ZZ -> ZZ -> Type
 quotientOverZZ x y = ( d : ZZ ** d<.>y=x )
 
-gcdOfVectZZ : (x : Vect n ZZ) -> ( v : Vect n ZZ ** ( i : Fin n ) -> (index i x) `quotientOverZZ` (v <:> x) )
+-- Making argument "k" implicit will not work.
+gcdOfVectAlg : Type
+gcdOfVectAlg = (k : Nat) -> (x : Vect k ZZ) -> ( v : Vect k ZZ ** ( i : Fin k ) -> (index i x) `quotientOverZZ` (v <:> x) )
 
-gaussElimlzIfGCD : (gcdOfVectAlg : {k : Nat} -> (x : Vect k ZZ) -> ( v : Vect k ZZ ** ( i : Fin k ) -> (index i x) `quotientOverZZ` (v <:> x) )) -> (xs : Matrix n m ZZ) -> (gexs : Matrix n' m ZZ ** (gexs `spanslz` xs, xs `spanslz` gexs, rowEchelon gexs))
+gaussElimlzIfGCD : Reader gcdOfVectAlg ( (xs : Matrix n m ZZ) -> (gexs : Matrix n' m ZZ ** (gexs `spanslz` xs, xs `spanslz` gexs, rowEchelon gexs)) )
+
+
+
+{-
+Background info
+-}
+
+
+
+gcdOfVectZZ : (x : Vect n ZZ) -> ( v : Vect n ZZ ** ( i : Fin n ) -> (index i x) `quotientOverZZ` (v <:> x) )
 
 
 
@@ -115,4 +131,4 @@ Main algorithm
 
 
 gaussElimlz : (xs : Matrix n m ZZ) -> (gexs : Matrix n' m ZZ ** (gexs `spanslz` xs, xs `spanslz` gexs, rowEchelon gexs))
-gaussElimlz = gaussElimlzIfGCD gcdOfVectZZ
+gaussElimlz = runIdentity $ runReaderT gaussElimlzIfGCD (\k => gcdOfVectZZ {n=k})

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -1024,13 +1024,21 @@ succImplWknProp {omat} nu fi tmat = ( tmat `spanslz` omat, omat `spanslz` tmat, 
 succImplWknPropSec3 : {omat : Matrix onnom (S predm) ZZ} -> (nu : Nat) -> (fi : Fin (S nu)) -> Matrix (S nu) (S predm) ZZ -> Type
 succImplWknPropSec3 {omat} nu fi tmat = downAndNotRightOfEntryImpliesZ tmat fi FZ
 
+succImplWknProp2 : (omat : Matrix onnom (S predm) ZZ) -> (nu : Nat) -> (fi : Fin (S nu)) -> Matrix (S nu) (S predm) ZZ -> Type
+succImplWknProp2 omat nu fi tmat = ( downAndNotRightOfEntryImpliesZ2 tmat fi FZ, tmat `spanslz` omat, omat `spanslz` tmat )
+succImplWknProp2Sec1 : (omat : Matrix onnom (S predm) ZZ) -> (nu : Nat) -> (fi : Fin (S nu)) -> Matrix (S nu) (S predm) ZZ -> Type
+succImplWknProp2Sec1 omat nu fi tmat = downAndNotRightOfEntryImpliesZ2 tmat fi FZ
+
 {-
-weakenTrivial : {omat : Matrix (S (S predn)) (S predm) ZZ} -> succImplWknPropSec3 {omat=omat} (S predn) (last {n=S predn}) omat
-weakenTrivial = void . notSNatLastLTEAnything
+danrzLast : {omat : Matrix (S (S predn)) (S predm) ZZ} -> succImplWknPropSec3 {omat=omat} (S predn) (last {n=S predn}) omat
+danrzLast = void . notSNatLastLTEAnything
 -}
 
-weakenTrivial : {omat : Matrix (S predn) (S predm) ZZ} -> succImplWknPropSec3 {omat=omat} predn (last {n=predn}) omat
-weakenTrivial = void . notSNatLastLTEAnything
+danrzLast : {omat : Matrix (S predn) (S predm) ZZ} -> succImplWknPropSec3 {omat=omat} predn (last {n=predn}) omat
+danrzLast = void . notSNatLastLTEAnything
+
+danrzLast2 : (omat : Matrix (S predn) (S predm) ZZ) -> succImplWknProp2Sec1 omat predn (last {n=predn}) omat
+danrzLast2 omat = (\i => \j => void . notSNatLastLTEAnything)
 
 {-
 Better to refine this to a type that depends on (m=S predm) so that the case (m=Z) may also be covered.
@@ -1079,7 +1087,7 @@ elimFirstCol2 mat {n=S predn} {predm} = do {
 		---
 		After much externalization for error isolation
 		---
-		let ( endmat ** endmatPropFn ) = foldAutoind2 (succImplWknProp {omat=(v <\> mat)::mat}) (succImplWknStep {v=v}) ( (v<\>mat)::mat ** (spanslzrefl, spanslzrefl, weakenTrivial {omat=(v <\> mat)::mat}) )
+		let ( endmat ** endmatPropFn ) = foldAutoind2 (succImplWknProp {omat=(v <\> mat)::mat}) (succImplWknStep {v=v}) ( (v<\>mat)::mat ** (spanslzrefl, spanslzrefl, danrzLast {omat=(v <\> mat)::mat}) )
 		-}
 
 		let ( endmat ** endmatPropFn ) = foldedFully {v=v}
@@ -1094,7 +1102,7 @@ elimFirstCol2 mat {n=S predn} {predm} = do {
 			-> ( imat : Matrix (S nu) (S predm) ZZ ** ( imat `spanslz` (v <\> mat)::mat, (v <\> mat)::mat `spanslz` imat, downAndNotRightOfEntryImpliesZ imat' (FS fi) FZ ) )
 			-> ( imat' : Matrix (S nu) (S predm) ZZ ** ( imat' `spanslz` (v <\> mat)::mat, (v <\> mat)::mat `spanslz` imat', downAndNotRightOfEntryImpliesZ imat' (weaken fi) FZ ) )
 		foldedFully : {v : Vect (S predn) ZZ} -> ( mats : Vect (S (S predn)) $ Matrix (S (S predn)) (S predm) ZZ ** (i : Fin (S (S predn))) -> succImplWknProp {omat=(v<\>mat)::mat} (S predn) i (index i mats) )
-		-- foldedFully {v} = foldAutoind2 (succImplWknProp {omat=(v <\> mat)::mat}) (succImplWknStep {v=v}) ( (v<\>mat)::mat ** (spanslzrefl, spanslzrefl, weakenTrivial {omat=(v <\> mat)::mat}) )
+		-- foldedFully {v} = foldAutoind2 (succImplWknProp {omat=(v <\> mat)::mat}) (succImplWknStep {v=v}) ( (v<\>mat)::mat ** (spanslzrefl, spanslzrefl, danrzLast {omat=(v <\> mat)::mat}) )
 -}
 elimFirstCol2 mat {n=S predn} {predm} = do {
 		gcdalg <- ask @{the (MonadReader ZZGaussianElimination.gcdOfVectAlg _) %instance}
@@ -1118,7 +1126,7 @@ elimFirstCol2 mat {n=S predn} {predm} = do {
 		---
 		After much externalization for error isolation
 		---
-		let ( endmat ** endmatPropFn ) = foldAutoind2 (succImplWknProp {omat=(v <\> mat)::mat}) (succImplWknStep {v=v}) ( (v<\>mat)::mat ** (spanslzrefl, spanslzrefl, weakenTrivial {omat=(v <\> mat)::mat}) )
+		let ( endmat ** endmatPropFn ) = foldAutoind2 (succImplWknProp {omat=(v <\> mat)::mat}) (succImplWknStep {v=v}) ( (v<\>mat)::mat ** (spanslzrefl, spanslzrefl, danrzLast {omat=(v <\> mat)::mat}) )
 		-}
 
 		let ( endmat ** endmatPropFn ) = foldedFully {v=v}
@@ -1518,7 +1526,31 @@ elimFirstCol2 mat {n=S predn} {predm} = do {
 				primatzAtWknFi = trans (cong {f=index FZ} $ indexUpdateAtChariz {xs=imat} {i=weaken fi} {f=(<-> (Sigma.getWitness $ fn (weaken fi)) <#> senior)}) $ trans (zipWithEntryChariz {i=FZ {k=predm}} {m=(<+>)} {x=index (weaken fi) imat} {y=inverse $ (Sigma.getWitness $ fn (weaken fi)) <#> senior}) $ trans (cong {f=plusZ $ indices (weaken fi) FZ imat} $ trans (indexCompatInverse ((<#>) (Sigma.getWitness $ fn $ weaken fi) senior) FZ) (cong {f=inverse} $ indexCompatScaling (Sigma.getWitness $ fn $ weaken fi) senior FZ)) $ trans (cong {f=(<->) $ indices (weaken fi) FZ imat} $ trans (cong {f=((Sigma.getWitness $ fn $ weaken fi)<.>)} $ indexFZIsheadValued {xs=senior}) $ getProof $ fn $ weaken fi) $ groupInverseIsInverseL $ indices (weaken fi) FZ imat
 				prfoo : downAndNotRightOfEntryImpliesZ2 witfoo (weaken fi) FZ
 				prfoo = weakenDownAndNotRight2 {prednel=fi} {mel=FZ} {mat=witfoo} (afterUpdateAtCurStillDownAndNotRight2 {mat=imat} {prednel=fi} {mel=FZ} {f=(<-> (Sigma.getWitness $ fn (weaken fi)) <#> senior)} imatDANRZ) primatzAtWknFi
-		foldedFully : {v : Vect (S predn) ZZ} -> ( mats : Vect (S (S predn)) $ Matrix (S (S predn)) (S predm) ZZ ** (i : Fin (S (S predn))) -> succImplWknProp {omat=(v<\>mat)::mat} (S predn) i (index i mats) )
+		succImplWknStep_lemma1_att8 : ( senior : Vect (S predm) ZZ ) -> ( srQfunc : ( i : Fin _ ) -> (indices i FZ (senior::mat)) `quotientOverZZ` (head senior) )
+			-> (fi : Fin (S predn))
+			-> ( imat : Matrix (S (S predn)) (S predm) ZZ )
+			-> ( downAndNotRightOfEntryImpliesZ2 {n=S $ S predn} {m=S predm} imat (FS fi) FZ, imat `spanslz` (senior::mat), (senior::mat) `spanslz` imat )
+			-> ( imat' : Matrix (S (S predn)) (S predm) ZZ ** downAndNotRightOfEntryImpliesZ2 {n=S $ S predn} {m=S predm} imat' (weaken fi) FZ )
+		succImplWknStep_lemma1_att8 senior srQfunc fi imat (imatDANRZ, imatSpansOrig, origSpansImat) = (witfoo ** prfoo)
+			where
+				fn : ( j : Fin _ ) -> (indices j FZ imat) `quotientOverZZ` (head senior)
+				fn = succImplWknStep_lemma2_att2 senior srQfunc imat origSpansImat
+				witfoo : Matrix (S (S predn)) (S predm) ZZ
+				witfoo = updateAt (weaken fi) (<-> (Sigma.getWitness $ fn (weaken fi)) <#> senior) imat
+				primatzAtWknFi : indices (weaken fi) FZ witfoo = Pos Z
+				primatzAtWknFi = trans (cong {f=index FZ} $ indexUpdateAtChariz {xs=imat} {i=weaken fi} {f=(<-> (Sigma.getWitness $ fn (weaken fi)) <#> senior)}) $ trans (zipWithEntryChariz {i=FZ {k=predm}} {m=(<+>)} {x=index (weaken fi) imat} {y=inverse $ (Sigma.getWitness $ fn (weaken fi)) <#> senior}) $ trans (cong {f=plusZ $ indices (weaken fi) FZ imat} $ trans (indexCompatInverse ((<#>) (Sigma.getWitness $ fn $ weaken fi) senior) FZ) (cong {f=inverse} $ indexCompatScaling (Sigma.getWitness $ fn $ weaken fi) senior FZ)) $ trans (cong {f=(<->) $ indices (weaken fi) FZ imat} $ trans (cong {f=((Sigma.getWitness $ fn $ weaken fi)<.>)} $ indexFZIsheadValued {xs=senior}) $ getProof $ fn $ weaken fi) $ groupInverseIsInverseL $ indices (weaken fi) FZ imat
+				prfoo : downAndNotRightOfEntryImpliesZ2 witfoo (weaken fi) FZ
+				prfoo = weakenDownAndNotRight2 {prednel=fi} {mel=FZ} {mat=witfoo} (afterUpdateAtCurStillDownAndNotRight2 {mat=imat} {prednel=fi} {mel=FZ} {f=(<-> (Sigma.getWitness $ fn (weaken fi)) <#> senior)} imatDANRZ) primatzAtWknFi
+		succImplWknStep_lemma1_plumbed : ( senior : Vect (S predm) ZZ ) -> ( srQfunc : ( i : Fin _ ) -> (indices i FZ (senior::mat)) `quotientOverZZ` (head senior) )
+			-> (fi : Fin (S predn))
+			-> ( imat : Matrix (S (S predn)) (S predm) ZZ ** ( downAndNotRightOfEntryImpliesZ2 {n=S $ S predn} {m=S predm} imat (FS fi) FZ, imat `spanslz` (senior::mat), (senior::mat) `spanslz` imat ) )
+			-> ( imat' : Matrix (S (S predn)) (S predm) ZZ ** downAndNotRightOfEntryImpliesZ2 {n=S $ S predn} {m=S predm} imat' (weaken fi) FZ )
+		succImplWknStep_lemma1_plumbed senior srQfunc fi imatAndPr = succImplWknStep_lemma1_att8 senior srQfunc fi (getWitness imatAndPr) (getProof imatAndPr)
+		succImplWknStep_att2 : (v : Vect (S predn) ZZ)
+			-> ( vmatQfunc : ( i : Fin _ ) -> (indices i FZ ((v <\> mat)::mat)) `quotientOverZZ` (head $ v <\> mat) )
+			-> (fi : Fin (S predn))
+			-> ( imat : Matrix (S (S predn)) (S predm) ZZ ** ( downAndNotRightOfEntryImpliesZ2 imat (FS fi) FZ, imat `spanslz` (v <\> mat)::mat, (v <\> mat)::mat `spanslz` imat ) )
+			-> ( imat' : Matrix (S (S predn)) (S predm) ZZ ** ( downAndNotRightOfEntryImpliesZ2 imat' (weaken fi) FZ, imat' `spanslz` (v <\> mat)::mat, (v <\> mat)::mat `spanslz` imat' ) )
 		{-
 		Type mismatch between
 		        Vect (S predn) ZZ (Type of v)
@@ -1531,7 +1563,7 @@ elimFirstCol2 mat {n=S predn} {predm} = do {
 		        and
 		                predm
 
-		> foldedFully {v} = foldAutoind3 {predn=S predn} (\ne => Matrix (S ne) (S predm) ZZ) (succImplWknProp {omat=(v <\> mat)::mat}) (succImplWknStep {v=v}) ( (v<\>mat)::mat ** (spanslzrefl, spanslzrefl, weakenTrivial {omat=(v <\> mat)::mat}) )
+		> foldedFully {v} = foldAutoind3 {predn=S predn} (\ne => Matrix (S ne) (S predm) ZZ) (succImplWknProp {omat=(v <\> mat)::mat}) (succImplWknStep {v=v}) ( (v<\>mat)::mat ** (spanslzrefl, spanslzrefl, danrzLast {omat=(v <\> mat)::mat}) )
 
 		similarly for
 
@@ -1558,7 +1590,12 @@ elimFirstCol2 mat {n=S predn} {predm} = do {
 
 		where on the third line at the very end, (imat') is referenced but doesn't exist yet.
 		-}
-		foldedFully {v} = foldAutoind3 {predn=S predn} (\ne => Matrix (S ne) (S predm) ZZ) (succImplWknProp {omat=(v <\> mat)::mat}) (succImplWknStep {v=v}) ( (v<\>mat)::mat ** (spanslzrefl, spanslzrefl, weakenTrivial {omat=(v <\> mat)::mat}) )
+		foldedFully : {v : Vect (S predn) ZZ} -> ( mats : Vect (S (S predn)) $ Matrix (S (S predn)) (S predm) ZZ ** (i : Fin (S (S predn))) -> succImplWknProp {omat=(v<\>mat)::mat} (S predn) i (index i mats) )
+		foldedFully {v} = foldAutoind3 {predn=S predn} (\ne => Matrix (S ne) (S predm) ZZ) (succImplWknProp {omat=(v <\> mat)::mat}) (succImplWknStep {v=v}) ( (v<\>mat)::mat ** (spanslzrefl, spanslzrefl, danrzLast {omat=(v <\> mat)::mat}) )
+		foldedFully_att2 : (v : Vect (S predn) ZZ)
+			-> ( vmatQfunc : ( i : Fin _ ) -> (indices i FZ ((v <\> mat)::mat)) `quotientOverZZ` (head $ v <\> mat) )
+			-> ( mats : Vect (S (S predn)) $ Matrix (S (S predn)) (S predm) ZZ ** (i : Fin (S (S predn))) -> succImplWknProp2 ((v<\>mat)::mat) (S predn) i (index i mats) )
+		foldedFully_att2 v vmatQfunc = foldAutoind3 {predn=S predn} (\ne => Matrix (S ne) (S predm) ZZ) (succImplWknProp2 ((v <\> mat)::mat)) (succImplWknStep_att2 v vmatQfunc) ( (v<\>mat)::mat ** (danrzLast2 ((v <\> mat)::mat), spanslzrefl, spanslzrefl) )
 
 {-
 Reference

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -1102,6 +1102,11 @@ succImplWknProp2 omat nu fi tmat = ( downAndNotRightOfEntryImpliesZ2 tmat fi FZ,
 succImplWknProp2Sec1 : (omat : Matrix onnom (S predm) ZZ) -> (nu : Nat) -> (fi : Fin (S nu)) -> Matrix (S nu) (S predm) ZZ -> Type
 succImplWknProp2Sec1 omat nu fi tmat = downAndNotRightOfEntryImpliesZ2 tmat fi FZ
 
+succImplWknProp3 : (omat : Matrix predonnom (S predm) ZZ) -> (senior : Vect (S predm) ZZ) -> (nu : Nat) -> (fi : Fin (S nu)) -> Matrix (S nu) (S predm) ZZ -> Type
+succImplWknProp3 omat senior nu fi tmat = ( senior = head tmat, downAndNotRightOfEntryImpliesZ2 tmat fi FZ, tmat `bispanslz` (senior::omat) )
+succImplWknProp3Sec2 : (nu : Nat) -> (fi : Fin (S nu)) -> Matrix (S nu) (S predm) ZZ -> Type
+succImplWknProp3Sec2 nu fi tmat = downAndNotRightOfEntryImpliesZ2 tmat fi FZ
+
 {-
 danrzLast : {omat : Matrix (S (S predn)) (S predm) ZZ} -> succImplWknPropSec3 {omat=omat} (S predn) (last {n=S predn}) omat
 danrzLast = void . notSNatLastLTEAnything
@@ -1112,6 +1117,9 @@ danrzLast = void . notSNatLastLTEAnything
 
 danrzLast2 : (omat : Matrix (S predn) (S predm) ZZ) -> succImplWknProp2Sec1 omat predn (last {n=predn}) omat
 danrzLast2 omat = (\i => \j => void . notSNatLastLTEAnything)
+
+danrzLast3 : (omat : Matrix (S predn) (S predm) ZZ) -> succImplWknProp3Sec2 predn (last {n=predn}) omat
+danrzLast3 omat = (\i => \j => void . notSNatLastLTEAnything)
 
 {-
 Better to refine this to a type that depends on (m=S predm) so that the case (m=Z) may also be covered.
@@ -1241,46 +1249,6 @@ elimFirstCol2 mat {n=S predn} {predm} = do {
 			=	(by groupInverseIsInverseL $ head (index (weaken fi) imat))
 			Pos Z
 		-}
-		succImplWknStep_lemma1_att8 : ( senior : Vect (S predm) ZZ ) -> ( srQfunc : ( i : Fin _ ) -> (indices i FZ (senior::mat)) `quotientOverZZ` (head senior) )
-			-> (fi : Fin (S predn))
-			-> ( imat : Matrix (S (S predn)) (S predm) ZZ )
-			-> ( downAndNotRightOfEntryImpliesZ2 {n=S $ S predn} {m=S predm} imat (FS fi) FZ, imat `spanslz` (senior::mat), (senior::mat) `spanslz` imat )
-			-> ( imat' : Matrix (S (S predn)) (S predm) ZZ ** downAndNotRightOfEntryImpliesZ2 {n=S $ S predn} {m=S predm} imat' (weaken fi) FZ )
-		succImplWknStep_lemma1_att8 senior srQfunc fi imat (imatDANRZ, imatSpansOrig, origSpansImat) = (witfoo ** prfoo)
-			where
-				fn : ( j : Fin _ ) -> (indices j FZ imat) `quotientOverZZ` (head senior)
-				fn = succImplWknStep_lemma2_att2 senior srQfunc imat origSpansImat
-				witfoo : Matrix (S (S predn)) (S predm) ZZ
-				witfoo = updateAt (weaken fi) (<-> (Sigma.getWitness $ fn (weaken fi)) <#> senior) imat
-				primatzAtWknFi : indices (weaken fi) FZ witfoo = Pos Z
-				primatzAtWknFi = trans (cong {f=index FZ} $ indexUpdateAtChariz {xs=imat} {i=weaken fi} {f=(<-> (Sigma.getWitness $ fn (weaken fi)) <#> senior)}) $ trans (zipWithEntryChariz {i=FZ {k=predm}} {m=(<+>)} {x=index (weaken fi) imat} {y=inverse $ (Sigma.getWitness $ fn (weaken fi)) <#> senior}) $ trans (cong {f=plusZ $ indices (weaken fi) FZ imat} $ trans (indexCompatInverse ((<#>) (Sigma.getWitness $ fn $ weaken fi) senior) FZ) (cong {f=inverse} $ indexCompatScaling (Sigma.getWitness $ fn $ weaken fi) senior FZ)) $ trans (cong {f=(<->) $ indices (weaken fi) FZ imat} $ trans (cong {f=((Sigma.getWitness $ fn $ weaken fi)<.>)} $ indexFZIsheadValued {xs=senior}) $ getProof $ fn $ weaken fi) $ groupInverseIsInverseL $ indices (weaken fi) FZ imat
-				prfoo : downAndNotRightOfEntryImpliesZ2 witfoo (weaken fi) FZ
-				prfoo = weakenDownAndNotRight2 {prednel=fi} {mel=FZ} {mat=witfoo} (afterUpdateAtCurStillDownAndNotRight2 {mat=imat} {prednel=fi} {mel=FZ} {f=(<-> (Sigma.getWitness $ fn (weaken fi)) <#> senior)} imatDANRZ) primatzAtWknFi
-		-- Including proof the head is equal to senior just makes this step easier.
-		succImplWknStep_modded : ( senior : Vect (S predm) ZZ ) -> ( srQfunc : ( i : Fin _ ) -> (indices i FZ (senior::mat)) `quotientOverZZ` (head senior) )
-			-> (fi : Fin (S predn))
-			-> ( imat : Matrix (S (S predn)) (S predm) ZZ )
-			-> ( senior = head imat, downAndNotRightOfEntryImpliesZ2 {n=S $ S predn} {m=S predm} imat (FS fi) FZ, imat `spanslz` (senior::mat), (senior::mat) `spanslz` imat )
-			-> ( imat' : Matrix (S (S predn)) (S predm) ZZ ** ( senior = head imat', downAndNotRightOfEntryImpliesZ2 {n=S $ S predn} {m=S predm} imat' (weaken fi) FZ, imat' `spanslz` (senior::mat), (senior::mat) `spanslz` imat' ) )
-		succImplWknStep_modded senior srQfunc fi imat ( seniorIsImatHead, imatDANRZ, imatSpansOrig, origSpansImat ) = (jmat ** ( seniorIsJmatHead, jmatDANRZ, jmatSpansOrig, origSpansJmat ) )
-			where
-				-- This and thus missingstep can't be implemented. We have used the wrong indexes in our definition of (jmat) and hence in our supporting lemmas for proving jmatDANRZ.
-				degeneracy : fi = FS fi'
-				missingstep : head imat = (Algebra.unity::Algebra.neutral) <\> deleteRow (weaken fi) imat
-				fn : ( j : Fin _ ) -> (indices j FZ imat) `quotientOverZZ` (head senior)
-				fn = succImplWknStep_lemma2_att2 senior srQfunc imat origSpansImat
-				jmat : Matrix (S (S predn)) (S predm) ZZ
-				jmat = updateAt (weaken fi) (<-> (Sigma.getWitness $ fn (weaken fi)) <#> senior) imat
-				seniorIsJmatHead : senior = head jmat
-				seniorIsJmatHead = trans seniorIsImatHead updateAtSuccRowVanishesUnderHead
-				primatzAtWknFi : indices (weaken fi) FZ jmat = Pos Z
-				primatzAtWknFi = trans (cong {f=index FZ} $ indexUpdateAtChariz {xs=imat} {i=weaken fi} {f=(<-> (Sigma.getWitness $ fn (weaken fi)) <#> senior)}) $ trans (zipWithEntryChariz {i=FZ {k=predm}} {m=(<+>)} {x=index (weaken fi) imat} {y=inverse $ (Sigma.getWitness $ fn (weaken fi)) <#> senior}) $ trans (cong {f=plusZ $ indices (weaken fi) FZ imat} $ trans (indexCompatInverse ((<#>) (Sigma.getWitness $ fn $ weaken fi) senior) FZ) (cong {f=inverse} $ indexCompatScaling (Sigma.getWitness $ fn $ weaken fi) senior FZ)) $ trans (cong {f=(<->) $ indices (weaken fi) FZ imat} $ trans (cong {f=((Sigma.getWitness $ fn $ weaken fi)<.>)} $ indexFZIsheadValued {xs=senior}) $ getProof $ fn $ weaken fi) $ groupInverseIsInverseL $ indices (weaken fi) FZ imat
-				jmatDANRZ : downAndNotRightOfEntryImpliesZ2 jmat (weaken fi) FZ
-				jmatDANRZ = weakenDownAndNotRight2 {prednel=fi} {mel=FZ} {mat=jmat} (afterUpdateAtCurStillDownAndNotRight2 {mat=imat} {prednel=fi} {mel=FZ} {f=(<-> (Sigma.getWitness $ fn (weaken fi)) <#> senior)} imatDANRZ) primatzAtWknFi
-				jmatSpansOrig : jmat `spanslz` (senior::mat)
-				jmatSpansOrig = spanslztrans (spanslzreflFromEq {xs=jmat} $ cong {f=\z => updateAt (weaken fi) (<-> z) imat} $ trans ( cong {f=((<#>) {a=ZZ} _)} $ trans seniorIsImatHead $ missingstep ) $ sym $ vectMatLScalingCompatibility {z=Sigma.getWitness $ fn $ weaken fi} {la=Algebra.unity::Algebra.neutral} {rs=deleteRow (weaken fi) imat}) $ spanslztrans ( spanslzSubtractiveExchangeAt (weaken fi) {xs=imat} {z=(Sigma.getWitness $ fn (weaken fi))<#>(Algebra.unity::Algebra.neutral)} ) $ imatSpansOrig
-				origSpansJmat : (senior::mat) `spanslz` jmat
-				origSpansJmat = ?succImplWknStep_origSpansJmat_pr
 		-- Including proof the head is equal to senior just makes this step easier.
 		succImplWknStep_modded_att2 : ( senior : Vect (S predm) ZZ ) -> ( srQfunc : ( i : Fin _ ) -> (indices i FZ (senior::mat)) `quotientOverZZ` (head senior) )
 			-> (fi : Fin (S predn))
@@ -1308,32 +1276,8 @@ elimFirstCol2 mat {n=S predn} {predm} = do {
 					$ trans ( cong {f=((head $ deleteRow (FS fi) imat)<+>)} $ trans (sym $ timesVectMatAsLinearCombo Algebra.neutral $ tail $ deleteRow (FS fi) imat) $ zzVecNeutralIsVecMatMultZero (tail $ deleteRow (FS fi) imat) )
 					$ trans ( zzVecNeutralIsNeutralL $ head $ deleteRow (FS fi) imat )
 					$ deleteSuccRowVanishesUnderHead {k=fi} {xs=imat}
-				{-
-				-- The first proof typechecks, but both these terms are subsumed by use of bispanslztrans.
-				jmatSpansOrig : jmat `spanslz` (senior::mat)
-				jmatSpansOrig = spanslztrans (spanslzreflFromEq {xs=jmat} $ cong {f=\z => updateAt (FS fi) (<-> z) imat} $ trans ( cong {f=((<#>) {a=ZZ} _)} $ trans seniorIsImatHead $ missingstep ) $ sym $ vectMatLScalingCompatibility {z=Sigma.getWitness $ fn $ FS fi} {la=Algebra.unity::Algebra.neutral} {rs=deleteRow (FS fi) imat}) $ spanslztrans ( spanslzSubtractiveExchangeAt (FS fi) {xs=imat} {z=(Sigma.getWitness $ fn (FS fi))<#>(Algebra.unity::Algebra.neutral)} ) $ imatSpansOrig
-				origSpansJmat : (senior::mat) `spanslz` jmat
-				origSpansJmat = ?succImplWknStep_origSpansJmat_pr
-				-}
 				jmatBispansOrig : jmat `bispanslz` (senior::mat)
 				jmatBispansOrig = bispanslztrans (bispanslzreflFromEq {xs=jmat} $ cong {f=\z => updateAt (FS fi) (<-> z) imat} $ trans ( cong {f=((<#>) {a=ZZ} _)} $ trans seniorIsImatHead $ missingstep ) $ sym $ vectMatLScalingCompatibility {z=Sigma.getWitness $ fn $ FS fi} {la=Algebra.unity::Algebra.neutral} {rs=deleteRow (FS fi) imat}) $ bispanslztrans ( bispanslzSubtractiveExchangeAt (FS fi) {xs=imat} {z=(Sigma.getWitness $ fn (FS fi))<#>(Algebra.unity::Algebra.neutral)} ) $ (imatSpansOrig, origSpansImat)
-		{-
-		Strategy for proving bispannability of the witness from the above:
-
-		< sym vectMatLScalingCompatibility
-
-		extends a proof that (senior)
-
-		is of the form (v_imat <\> tau)
-
-		to a proof that for all s,
-
-		< s<#>senior
-
-		is of the form (v_imat <\> tau).
-
-		Then (spanslzSubtractiveExchangeAt (weaken fi)) (or its bispanning version) can be applied to produce the spanslz proofs, for (tau = deleteRow (weaken fi) imat).
-		-}
 		succImplWknStep_unplumbed : (v : Vect (S predn) ZZ)
 			-> ( vmatQfunc : ( i : Fin _ ) -> (indices i FZ ((v <\> mat)::mat)) `quotientOverZZ` (head $ v <\> mat) )
 			-> (fi : Fin (S predn))
@@ -1346,6 +1290,11 @@ elimFirstCol2 mat {n=S predn} {predm} = do {
 			-> ( imat : Matrix (S (S predn)) (S predm) ZZ ** ( downAndNotRightOfEntryImpliesZ2 imat (FS fi) FZ, imat `spanslz` (v <\> mat)::mat, (v <\> mat)::mat `spanslz` imat ) )
 			-> ( imat' : Matrix (S (S predn)) (S predm) ZZ ** ( downAndNotRightOfEntryImpliesZ2 imat' (weaken fi) FZ, imat' `spanslz` (v <\> mat)::mat, (v <\> mat)::mat `spanslz` imat' ) )
 		succImplWknStep_att2 senior srQfunc fi imatAndPrs = succImplWknStep_unplumbed senior srQfunc fi (getWitness imatAndPrs) (getProof imatAndPrs)
+		succImplWknStep_att3 : ( senior : Vect (S predm) ZZ ) -> ( srQfunc : ( i : Fin _ ) -> (indices i FZ (senior::mat)) `quotientOverZZ` (head senior) )
+			-> (fi : Fin (S predn))
+			-> ( imat : Matrix (S (S predn)) (S predm) ZZ ** ( senior = head imat, downAndNotRightOfEntryImpliesZ2 {n=S $ S predn} {m=S predm} imat (FS fi) FZ, imat `spanslz` (senior::mat), (senior::mat) `spanslz` imat ) )
+			-> ( imat' : Matrix (S (S predn)) (S predm) ZZ ** ( senior = head imat', downAndNotRightOfEntryImpliesZ2 {n=S $ S predn} {m=S predm} imat' (weaken fi) FZ, imat' `spanslz` (senior::mat), (senior::mat) `spanslz` imat' ) )
+		succImplWknStep_att3 senior srQfunc fi imatAndPrs = succImplWknStep_modded_att2 senior srQfunc fi (getWitness imatAndPrs) (getProof imatAndPrs)
 		{-
 		Type mismatch between
 		        Vect (S predn) ZZ (Type of v)
@@ -1391,6 +1340,10 @@ elimFirstCol2 mat {n=S predn} {predm} = do {
 			-> ( vmatQfunc : ( i : Fin _ ) -> (indices i FZ ((v <\> mat)::mat)) `quotientOverZZ` (head $ v <\> mat) )
 			-> ( mats : Vect (S (S predn)) $ Matrix (S (S predn)) (S predm) ZZ ** (i : Fin (S (S predn))) -> succImplWknProp2 ((v<\>mat)::mat) (S predn) i (index i mats) )
 		foldedFully_att2 v vmatQfunc = foldAutoind3 {predn=S predn} (\ne => Matrix (S ne) (S predm) ZZ) (succImplWknProp2 ((v <\> mat)::mat)) (succImplWknStep_att2 v vmatQfunc) ( (v<\>mat)::mat ** (danrzLast2 ((v <\> mat)::mat), spanslzrefl, spanslzrefl) )
+		foldedFully_att3 : (v : Vect (S predn) ZZ)
+			-> ( vmatQfunc : ( i : Fin _ ) -> (indices i FZ ((v <\> mat)::mat)) `quotientOverZZ` (head $ v <\> mat) )
+			-> ( mats : Vect (S (S predn)) $ Matrix (S (S predn)) (S predm) ZZ ** (i : Fin (S (S predn))) -> succImplWknProp3 mat (v<\>mat) (S predn) i (index i mats) )
+		foldedFully_att3 v vmatQfunc = foldAutoind3 {predn=S predn} (\ne => Matrix (S ne) (S predm) ZZ) (succImplWknProp3 mat (v <\> mat)) (succImplWknStep_att3 (v <\> mat) vmatQfunc) ( (v<\>mat)::mat ** (Refl, danrzLast3 ((v <\> mat)::mat), bispanslzrefl) )
 
 {-
 Reference

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -11,6 +11,7 @@ import Control.Algebra.NumericInstances
 import Control.Algebra.ZZVerifiedInstances
 
 import ZZModuleSpan
+import Data.Matrix.LinearCombinations
 
 import FinOrdering
 
@@ -846,6 +847,23 @@ elimFirstCol2 mat {n=S predn} {predm} = do {
 			-> (fi : Fin (S predn))
 			-> ( imat : Matrix (S (S predn)) (S predm) ZZ ** ( imat `spanslz` (v <\> mat)::mat, (v <\> mat)::mat `spanslz` imat, downAndNotRightOfEntryImpliesZ imat (FS fi) FZ ) )
 			-> ( imat' : Matrix (S (S predn)) (S predm) ZZ ** ( imat' `spanslz` (v <\> mat)::mat, (v <\> mat)::mat `spanslz` imat', downAndNotRightOfEntryImpliesZ imat' (weaken fi) FZ ) )
+		succImplWknStep_lemma1 : ( senior : Vect (S predm) ZZ ) -> ( srQfunc : ( i : Fin _ ) -> (indices i FZ (senior::mat)) `quotientOverZZ` (head senior) )
+			-> (fi : Fin (S predn))
+			-> ( imat : Matrix (S (S predn)) (S predm) ZZ ** ( imat `spanslz` senior::mat, senior::mat `spanslz` imat, downAndNotRightOfEntryImpliesZ imat (FS fi) FZ ) )
+			-> ( imat' : Matrix (S (S predn)) (S predm) ZZ ** ( downAndNotRightOfEntryImpliesZ imat' (weaken fi) FZ ) )
+		succImplWknStep_lemma1 = ?succImplWknStep_lemma1_pr
+		succImplWknStep_lemma2 : ( senior : Vect (S predm) ZZ ) -> ( srQfunc : ( i : Fin _ ) -> (indices i FZ (senior::mat)) `quotientOverZZ` (head senior) )
+			-> (fi : Fin (S predn))
+			-> ( imat : Matrix (S (S predn)) (S predm) ZZ )
+			-> ( reprolem : senior::mat `spanslz` imat )
+			-> ( ( j : Fin _ ) -> (indices j FZ imat) `quotientOverZZ` (head senior) )
+		succImplWknStep_lemma2 = ?succImplWknStep_lemma2_pr
+		succImplWknStep_lemma3 : ( senior : Vect (S predm) ZZ ) -> ( srQfunc : ( i : Fin _ ) -> (indices i FZ (senior::mat)) `quotientOverZZ` (head senior) )
+			-> (fi : Fin (S predn))
+			-> ( imat : Matrix (S (S predn)) (S predm) ZZ )
+			-> ( quotchariz : ( z : Matrix _ _ ZZ ) -> ( k : Fin _ ) -> ( LinearCombinations.monoidsum $ zipWith (<#>) (index k z) (senior::mat) = index k imat ) )
+			-> ( ( j : Fin _ ) -> (indices j FZ imat) `quotientOverZZ` (head senior) )
+		succImplWknStep_lemma3 = ?succImplWknStep_lemma3_pr
 		foldedFully : {v : Vect (S predn) ZZ} -> ( mats : Vect (S (S predn)) $ Matrix (S (S predn)) (S predm) ZZ ** (i : Fin (S (S predn))) -> succImplWknProp {omat=(v<\>mat)::mat} (S predn) i (index i mats) )
 		{-
 		Type mismatch between

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -1098,7 +1098,39 @@ elimFirstCol2 mat {n=S predn} {predm} = do {
 			-> ( ( j : Fin _ ) -> (indices j FZ imat) `quotientOverZZ` (head senior) )
 		succImplWknStep_lemma3 = ?succImplWknStep_lemma3_pr
 		-- linearComboQuotientRelation
-		-- linearComboQuotientRelation2_corrollary
+		succImplWknStep_lemma3_att2 : ( senior : Vect (S predm) ZZ ) -> ( srQfunc : ( i : Fin _ ) -> (indices i FZ (senior::mat)) `quotientOverZZ` (head senior) )
+			-> ( imat : Matrix (S (S predn)) (S predm) ZZ )
+			-> ( z : Matrix _ _ ZZ )
+			-> ( quotchariz : ( k : Fin _ ) -> ( LinearCombinations.monoidsum $ zipWith (<#>) (index k z) (senior::mat) = index k imat ) )
+			-> ( ( j : Fin _ ) -> (indices j FZ imat) `quotientOverZZ` (head senior) )
+		{-
+		-- This version is perhaps more readable.
+
+		succImplWknStep_lemma3_att2 senior srQfunc imat z quotchariz j ?= linearComboQuotientRelation2_corrollary senior mat (index j z) (\i => quotientOverZZtrans (quotientOverZZreflFromEq $ sym indexFZIsheadValued) $ srQfunc i)
+		succImplWknStep_lemma3_att2_lemma_1 = proof
+			intros
+			exact (getWitness value ** _)
+			rewrite sym $ indexFZIsheadValued {xs=index j imat}
+			rewrite cong {f=head} $ quotchariz j
+			exact getProof value
+		-}
+		succImplWknStep_lemma3_att2 senior srQfunc imat z quotchariz j = (getWitness lemma ** trans (getProof lemma) $ trans (cong {f=head} $ quotchariz j) $ sym $ indexFZIsheadValued {xs=index j imat})
+			where
+				lemma : (head $ monoidsum $ zipWith (<#>) (index j z) (senior::mat)) `quotientOverZZ` (head senior)
+				lemma = linearComboQuotientRelation2_corrollary senior mat (index j z) (\i => quotientOverZZtrans (quotientOverZZreflFromEq $ sym indexFZIsheadValued) $ srQfunc i)
+		succImplWknStep_lemma2_att2 : ( senior : Vect (S predm) ZZ ) -> ( srQfunc : ( i : Fin _ ) -> (indices i FZ (senior::mat)) `quotientOverZZ` (head senior) )
+			-> ( imat : Matrix (S (S predn)) (S predm) ZZ )
+			-> ( reprolem : senior::mat `spanslz` imat )
+			-> ( ( j : Fin _ ) -> (indices j FZ imat) `quotientOverZZ` (head senior) )
+		succImplWknStep_lemma2_att2 senior srQfunc imat reprolem = succImplWknStep_lemma3_att2 senior srQfunc imat (getWitness reprolem) (\k => trans (sym indexMapChariz) $ cong {f=index k} $ getProof reprolem)
+		succImplWknStep_lemma1_att2 : ( senior : Vect (S predm) ZZ ) -> ( srQfunc : ( i : Fin _ ) -> (indices i FZ (senior::mat)) `quotientOverZZ` (head senior) )
+			-> (fi : Fin (S predn))
+			-> ( imat : Matrix (S (S predn)) (S predm) ZZ ** ( imat `spanslz` (senior::mat), (senior::mat) `spanslz` imat, downAndNotRightOfEntryImpliesZ imat (FS fi) FZ ) )
+			-> ( imat' : Matrix (S (S predn)) (S predm) ZZ ** ( downAndNotRightOfEntryImpliesZ imat' (weaken fi) FZ ) )
+		succImplWknStep_lemma1_att2 senior srQfunc fi (imat ** (imatpr1, imatpr2, imatpr3)) = ?succImplWknStep_lemma1_att2_pr
+			where
+				fn : ( j : Fin _ ) -> (indices j FZ imat) `quotientOverZZ` (head senior)
+				fn = succImplWknStep_lemma2_att2 senior srQfunc imat imatpr2
 		foldedFully : {v : Vect (S predn) ZZ} -> ( mats : Vect (S (S predn)) $ Matrix (S (S predn)) (S predm) ZZ ** (i : Fin (S (S predn))) -> succImplWknProp {omat=(v<\>mat)::mat} (S predn) i (index i mats) )
 		{-
 		Type mismatch between

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -99,6 +99,15 @@ Intermediate or secondary algorithms
 
 
 
+quotientOverZZ : ZZ -> ZZ -> Type
+quotientOverZZ x y = ( d : ZZ ** d<.>y=x )
+
+gcdOfVectZZ : (x : Vect n ZZ) -> ( v : Vect n ZZ ** ( i : Fin n ) -> (index i x) `quotientOverZZ` (v <:> x) )
+
+gaussElimlzIfGCD : (gcdOfVectAlg : {k : Nat} -> (x : Vect k ZZ) -> ( v : Vect k ZZ ** ( i : Fin k ) -> (index i x) `quotientOverZZ` (v <:> x) )) -> (xs : Matrix n m ZZ) -> (gexs : Matrix n' m ZZ ** (gexs `spanslz` xs, xs `spanslz` gexs, rowEchelon gexs))
+
+
+
 {-
 Main algorithm
 -}
@@ -106,3 +115,4 @@ Main algorithm
 
 
 gaussElimlz : (xs : Matrix n m ZZ) -> (gexs : Matrix n' m ZZ ** (gexs `spanslz` xs, xs `spanslz` gexs, rowEchelon gexs))
+gaussElimlz = gaussElimlzIfGCD gcdOfVectZZ

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -481,6 +481,10 @@ foldAutoind3 : ( a : Nat -> Type )
 		-> ( w' : a predn ** p _ (weaken i) w' ) )
 	-> ( v : a predn ** p _ (last {n=predn}) v )
 	-> ( xs : Vect (S predn) (a predn) ** (i : Fin (S predn)) -> p _ i (index i xs) )
+foldAutoind3 {predn=Z} _ p regr (v ** pv) = ( [v] ** \i => rewrite sym (the (FZ = i) $ sym $ FinSZAreFZ i) in pv )
+foldAutoind3 {predn=S prededn} natToA p regr (v ** pv) with (regr (last {n=prededn}) (v ** pv))
+	-- Compare with the corresponding (outer) with block in foldAutoind2
+	| (v' ** pv') = ?fai3_induceMe
 
 
 

--- a/ZZGaussianElimination.idr
+++ b/ZZGaussianElimination.idr
@@ -54,8 +54,6 @@ commuteFSWeaken i = Refl
 
 splitFinS : (i : Fin (S predn)) -> Either ( k : Fin predn ** i = weaken k ) ( i = Data.Fin.last )
 
--- lastInd : {xs : Vect n a} -> Data.Vect.index Data.Fin.last (rewrite ( cong {f=\k => Vect k a} $ trans (cong {f=S} $ sym $ plusZeroRightNeutral n) $ plusSuccRightSucc n Z ) in (xs++[v])) = v
-
 plusOneVectIsSuccVect : Vect (n+1) a = Vect (S n) a
 plusOneVectIsSuccVect {a} {n} = sym $ cong {f=\k => Vect k a} $ trans (cong {f=S} $ sym $ plusZeroRightNeutral n) $ plusSuccRightSucc n Z
 

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -367,6 +367,9 @@ spanslz {n} {n'} xs ys = (vs : Matrix n' n ZZ ** zippyScale {n'=n'} {n=n} vs xs 
 spanslz : (xs : Matrix n w ZZ) -> (ys : Matrix n' w ZZ) -> Type
 spanslz {n} {n'} xs ys = (vs : Matrix n' n ZZ ** vs `zippyScale` xs = ys)
 
+bispanslz : (xs : Matrix n w ZZ) -> (ys : Matrix n' w ZZ) -> Type
+bispanslz xs ys = (xs `spanslz` ys, ys `spanslz` xs)
+
 
 
 {-
@@ -471,13 +474,19 @@ spanslztrans {na} {ni} {nu} {m} {xs} {ys} {zs} (vsx ** prvsx) (vsy ** prvsy) = (
 		spanslztrans_linearcombprop : spanslztrans_matrix `zippyScale` xs = zs
 		spanslztrans_linearcombprop = trans (cong {f=(flip zippyScale) xs} $ timesMatMatAsMultipleLinearCombos vsy vsx) $ trans (sym $ zippyScaleIsAssociative {l=vsy} {c=vsx} {r=xs}) $ trans (cong {f=zippyScale vsy} prvsx) prvsy
 
+bispanslztrans : {xs : Matrix na m ZZ} -> {ys : Matrix ni m ZZ} -> {zs : Matrix nu m ZZ} -> bispanslz {n=na} {n'=ni} xs ys -> bispanslz {n=ni} {n'=nu} ys zs -> bispanslz xs zs
+
 
 
 spanslzrefl : spanslz xs xs
 spanslzrefl = ( Id ** zippyScaleIdLeftNeutral _ )
 
+bispanslzrefl : bispanslz xs xs
+
 spanslzreflFromEq : (xs=ys) -> xs `spanslz` ys
 spanslzreflFromEq pr = ( Id ** trans (zippyScaleIdLeftNeutral _) pr )
+
+bispanslzreflFromEq : (xs=ys) -> xs `bispanslz` ys
 
 
 
@@ -652,3 +661,9 @@ spanslzSubtractiveExchangeAt : (nel : Fin (S predn)) -> spanslz (updateAt nel (<
 spanslzAdditivePreservationAt : (nel : Fin (S predn)) -> spanslz xs (updateAt nel (<+>(z<\>(deleteRow nel xs))) xs)
 
 spanslzSubtractivePreservationAt : (nel : Fin (S predn)) -> spanslz xs (updateAt nel (<->(z<\>(deleteRow nel xs))) xs)
+
+bispanslzAdditiveExchangeAt : (nel : Fin (S predn)) -> bispanslz (updateAt nel (<+>(z<\>(deleteRow nel xs))) xs) xs
+bispanslzAdditiveExchangeAt nel = (spanslzAdditiveExchangeAt nel, spanslzAdditivePreservationAt nel)
+
+bispanslzSubtractiveExchangeAt : (nel : Fin (S predn)) -> bispanslz (updateAt nel (<->(z<\>(deleteRow nel xs))) xs) xs
+bispanslzSubtractiveExchangeAt nel = (spanslzSubtractiveExchangeAt nel, spanslzSubtractivePreservationAt nel)

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -12,6 +12,9 @@ import Data.ZZ
 import Control.Algebra.NumericInstances
 import Control.Algebra.ZZVerifiedInstances
 
+import Data.Vect.Structural
+-- import Data.Matrix.Structural
+
 import Control.Isomorphism
 
 
@@ -19,11 +22,6 @@ import Control.Isomorphism
 {-
 Trivial lemmas and plumbing
 -}
-
-vecHeadtailsEq : {xs,ys : Vect _ _} -> ( headeq : x = y ) -> ( taileq : xs = ys ) -> x::xs = y::ys
-vecHeadtailsEq {x} {xs} {ys} headeq taileq = trans (vectConsCong x xs ys taileq) $ cong {f=(::ys)} headeq
--- Also a solid proof:
--- vecHeadtailsEq {x} {xs} {ys} headeq taileq = trans (cong {f=(::xs)} headeq) $ replace {P=\l => l::xs = l::ys} headeq $ vectConsCong x xs ys taileq
 
 runIso : Iso a b -> a -> b
 runIso (MkIso to _ _ _) = to

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -473,6 +473,12 @@ spanslztrans {na} {ni} {nu} {m} {xs} {ys} {zs} (vsx ** prvsx) (vsy ** prvsy) = (
 		spanslztrans_linearcombprop = trans (cong {f=(flip zippyScale) xs} $ timesMatMatAsMultipleLinearCombos vsy vsx) $ trans (sym $ zippyScaleIsAssociative {l=vsy} {c=vsx} {r=xs}) $ trans (cong {f=zippyScale vsy} prvsx) prvsy
 
 bispanslztrans : {xs : Matrix na m ZZ} -> {ys : Matrix ni m ZZ} -> {zs : Matrix nu m ZZ} -> bispanslz {n=na} {n'=ni} xs ys -> bispanslz {n=ni} {n'=nu} ys zs -> bispanslz xs zs
+bispanslztrans (sxy,syx) (syz,szy) = (spanslztrans sxy syz, spanslztrans szy syx)
+
+
+
+bispanslzsym : xs `bispanslz` ys -> ys `bispanslz` xs
+bispanslzsym = swap
 
 
 
@@ -480,6 +486,7 @@ spanslzrefl : spanslz xs xs
 spanslzrefl = ( Id ** zippyScaleIdLeftNeutral _ )
 
 bispanslzrefl : bispanslz xs xs
+bispanslzrefl = (spanslzrefl, spanslzrefl)
 
 spanslzreflFromEq : (xs=ys) -> xs `spanslz` ys
 spanslzreflFromEq pr = ( Id ** trans (zippyScaleIdLeftNeutral _) pr )

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -645,3 +645,7 @@ spanslzAdditiveExchangeAt : (nel : Fin (S predn)) -> spanslz (updateAt nel (<+>(
 spanslzAdditiveExchangeAt nel {predn} {xs} {z} = headOpPreservesSpanslzImpliesUpdateAtDoes {f=\argxx => \argxxs => argxx<+>(z<\>argxxs) } (\argxx => \argxxs => spanslzAdditiveExchange {y=argxx} {xs=argxxs} {z=z}) nel xs
 
 spanslzSubtractiveExchangeAt : (nel : Fin (S predn)) -> spanslz (updateAt nel (<->(z<\>(deleteRow nel xs))) xs) xs
+
+spanslzAdditivePreservationAt : (nel : Fin (S predn)) -> spanslz xs (updateAt nel (<+>(z<\>(deleteRow nel xs))) xs)
+
+spanslzSubtractivePreservationAt : (nel : Fin (S predn)) -> spanslz xs (updateAt nel (<->(z<\>(deleteRow nel xs))) xs)

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -476,6 +476,9 @@ spanslztrans {na} {ni} {nu} {m} {xs} {ys} {zs} (vsx ** prvsx) (vsy ** prvsy) = (
 spanslzrefl : spanslz xs xs
 spanslzrefl = ( Id ** zippyScaleIdLeftNeutral _ )
 
+spanslzreflFromEq : (xs=ys) -> xs `spanslz` ys
+spanslzreflFromEq pr = ( Id ** trans (zippyScaleIdLeftNeutral _) pr )
+
 
 
 updateAtEquality : {ls : Matrix n k ZZ} -> {rs : Matrix k m ZZ} -> (updi : Fin n) -> (f : (i : Nat) -> Vect i ZZ -> Vect i ZZ) -> ( (la : Vect k ZZ) -> (f k la) <\> rs = f m $ la <\> rs ) -> (updateAt updi (f k) ls) `zippyScale` rs = updateAt updi (f m) (ls `zippyScale` rs)


### PR DESCRIPTION
Implement (elimFirstCol), the base case of gaussian elimination, by which the leftmost column is eliminated, introducing constructions like (foldAutoind2) and organizing many of the lemmas into modules along the way.
