### PR TITLE
ZZModuleSpan complete

### DIFF
--- a/Data/Matrix/AlgebraicVerified.idr
+++ b/Data/Matrix/AlgebraicVerified.idr
@@ -187,8 +187,33 @@ Trivial identities about (unital) rings.
 -- Actually theorems about quasigroups
 groupOpIsCancellativeL : VerifiedGroup a => (left, right1, right2 : a) -> left<+>right1 = left<+>right2 -> right1=right2
 groupOpIsCancellativeL left right1 right2 pr = trans (sym $ trans (cong {f=(<+>right1)} $ groupInverseIsInverseR left) $ monoidNeutralIsNeutralR right1) $ trans (trans (sym $ semigroupOpIsAssociative (inverse left) left right1) $ trans (cong {f=((inverse left)<+>)} pr) $ semigroupOpIsAssociative (inverse left) left right2) $ trans (cong {f=(<+>right2)} $ groupInverseIsInverseR left) $ monoidNeutralIsNeutralR right2
+
 groupOpIsCancellativeR : VerifiedGroup a => (left1, left2, right : a) -> left1<+>right = left2<+>right -> left1=left2
 groupOpIsCancellativeR left1 left2 right pr = trans (sym $ trans (cong {f=(left1<+>)} $ groupInverseIsInverseL right) $ monoidNeutralIsNeutralL left1) $ trans (trans (semigroupOpIsAssociative left1 right (inverse right)) $ trans (cong {f=(<+>(inverse right))} pr) $ sym $ semigroupOpIsAssociative left2 right (inverse right)) $ trans (cong {f=(left2<+>)} $ groupInverseIsInverseL right) $ monoidNeutralIsNeutralL left2
+
+groupOpIsCancellativeL_Vect : VerifiedRingWithUnity a =>
+	(left, right1, right2 : Vect n a)
+	-> left<+>right1 = left<+>right2 -> right1=right2
+groupOpIsCancellativeL_Vect left right1 right2 pr =
+	trans (sym $ trans (cong {f=(<+>right1)} $ groupInverseIsInverseR_Vect left)
+		$ monoidNeutralIsNeutralR_Vect right1)
+	$ trans (trans (sym $ semigroupOpIsAssociative_Vect (inverse left) left right1)
+		$ trans (cong {f=((inverse left)<+>)} pr)
+		$ semigroupOpIsAssociative_Vect (inverse left) left right2)
+	$ trans (cong {f=(<+>right2)} $ groupInverseIsInverseR_Vect left)
+	$ monoidNeutralIsNeutralR_Vect right2
+
+groupOpIsCancellativeR_Vect : VerifiedRingWithUnity a =>
+	(left1, left2, right : Vect n a)
+	-> (left1 <+> right = left2 <+> right) -> left1 = left2
+groupOpIsCancellativeR_Vect left1 left2 right pr =
+	trans (sym $ trans (cong {f=(left1<+>)} $ groupInverseIsInverseL_Vect right)
+		$ monoidNeutralIsNeutralL_Vect left1)
+	$ trans (trans (semigroupOpIsAssociative_Vect left1 right (inverse right))
+		$ trans (cong {f=(<+>(inverse right))} pr)
+		$ sym $ semigroupOpIsAssociative_Vect left2 right (inverse right))
+	$ trans (cong {f=(left2<+>)} $ groupInverseIsInverseL_Vect right)
+	$ monoidNeutralIsNeutralL_Vect left2
 
 -- Not used for the below, but for elsewhere.
 neutralSelfInverse : VerifiedGroup a => inverse $ the a $ Algebra.neutral = the a $ Algebra.neutral
@@ -199,6 +224,7 @@ groupElemOwnDoubleImpliesNeut x pr = groupOpIsCancellativeL x x Algebra.neutral 
 
 ringNeutralIsMultZeroL : VerifiedRing a => (x : a) -> Algebra.neutral <.> x = Algebra.neutral
 ringNeutralIsMultZeroL x = groupElemOwnDoubleImpliesNeut (Algebra.neutral <.> x) $ trans (sym $ ringOpIsDistributiveR Algebra.neutral Algebra.neutral x) $ cong {f=(<.>x)} $ monoidNeutralIsNeutralL Algebra.neutral
+
 ringNeutralIsMultZeroR : VerifiedRing a => (x : a) -> x <.> Algebra.neutral = Algebra.neutral
 ringNeutralIsMultZeroR x = groupElemOwnDoubleImpliesNeut (x <.> Algebra.neutral) $ trans (sym $ ringOpIsDistributiveL x Algebra.neutral Algebra.neutral) $ cong {f=(x<.>)} $ monoidNeutralIsNeutralL Algebra.neutral
 

--- a/Data/Matrix/LinearCombinations.idr
+++ b/Data/Matrix/LinearCombinations.idr
@@ -728,6 +728,11 @@ neutralVectIsVectTimesZero xs {mu=S predmu} = trans timesVectMatAsHeadTail_ByTra
 		(neutralVectIsDotProductZero_L $ map head xs)
 		$ neutralVectIsVectTimesZero $ map tail xs
 
+emptyVectIsTimesVectZero : (x : Matrix nu Z ZZ) -> x</>[] = Algebra.neutral
+emptyVectIsTimesVectZero [] = Refl
+emptyVectIsTimesVectZero (x::xs) = vecHeadtailsEq (neutralVectIsDotProductZero_L x)
+	$ emptyVectIsTimesVectZero xs
+
 neutralMatIsMultZeroL : (x : Matrix nu mu ZZ) -> Algebra.neutral <> x = Algebra.neutral
 neutralMatIsMultZeroL x = vecIndexwiseEq $ \i => trans indexMapChariz $ trans (cong {f=(<\>x)} indexReplicateChariz) $ trans (neutralVectIsVectTimesZero x) $ sym $ indexReplicateChariz
 

--- a/Data/Matrix/LinearCombinations.idr
+++ b/Data/Matrix/LinearCombinations.idr
@@ -75,6 +75,14 @@ doubleSumInnerSwap a b c d = trans (sym $ semigroupOpIsAssociative a b (c<+>d))
 		$ sym $ semigroupOpIsAssociative c b d)
 	$ semigroupOpIsAssociative a c (b<+>d)
 
+doubleSumInnerSwap_Vect : VerifiedRingWithUnity t => (a, b, c, d : Vect n t)
+	-> (a<+>b)<+>(c<+>d) = (a<+>c)<+>(b<+>d)
+doubleSumInnerSwap_Vect a b c d = trans (sym $ semigroupOpIsAssociative_Vect a b (c<+>d))
+	$ trans ( cong {f=(a<+>)} $ trans (semigroupOpIsAssociative_Vect b c d)
+		$ trans (cong {f=(<+>d)} $ abelianGroupOpIsCommutative_Vect b c)
+		$ sym $ semigroupOpIsAssociative_Vect c b d)
+	$ semigroupOpIsAssociative_Vect a c (b<+>d)
+
 
 
 lemma_VectAddHead : (v, w : Vect (S n) ZZ) -> head(v<+>w) = (head v)<+>(head w)

--- a/Data/Vect/Structural.idr
+++ b/Data/Vect/Structural.idr
@@ -94,8 +94,17 @@ indexUpdateAtChariz {xs=(x::xs)} {f} {i=FZ} = Refl
 indexUpdateAtChariz {xs=x::xs} {f} {i=FS i} = indexUpdateAtChariz {xs=xs} {f=f} {i=i}
 
 indexUpdateAtChariz2 : Not (i = j) -> index i $ updateAt j f xs = index i xs
+indexUpdateAtChariz2 prneq {i=FZ} {j=FZ} = void $ prneq Refl
+indexUpdateAtChariz2 prneq {i=FS k} {j=FZ} {xs=x::xs} = Refl
+indexUpdateAtChariz2 prneq {i=FZ} {j=FS k} {xs=x::xs} = Refl
+indexUpdateAtChariz2 prneq {i=FS ki} {j=FS kj} {xs=x::xs} = indexUpdateAtChariz2 {xs=xs}
+	$ prneq . (cong {f=FS})
 
 updateDeleteAtChariz : deleteAt i $ updateAt i f xs = deleteAt i xs
+updateDeleteAtChariz {i=FZ} {xs=x::xs} = Refl
+updateDeleteAtChariz {i=FS k} {xs=x::[]} = FinZElim k
+updateDeleteAtChariz {i=FS k} {xs=x::x2::xs} = cong {f=(x::)}
+	$ updateDeleteAtChariz {i=k} {xs=x2::xs}
 
 updateAtIndIsMapAtInd : index i $ updateAt i f xs = index i $ map f xs
 updateAtIndIsMapAtInd = trans indexUpdateAtChariz $ sym indexMapChariz

--- a/FinOrdering.idr
+++ b/FinOrdering.idr
@@ -75,3 +75,9 @@ instance DecLT (Fin n) where
 -}
 
 lteToLTERel : {a, b : Nat} -> LTE a b -> LTERel a b
+lteToLTERel LTEZero {b=Z} = Right Refl
+lteToLTERel LTEZero {b=S predb} = Left $ LTESucc $ LTEZero {right=predb}
+lteToLTERel (LTESucc ltepr) {a=S preda} {b=S predb} = either
+	(Left . LTESucc)
+	(Right . (cong {f=S}))
+	$ lteToLTERel ltepr

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -60,28 +60,6 @@ indexConcatAsIndexAppended : (i : Fin m) -> index (shift n i) $ xs++ys = index i
 indexConcatAsIndexAppended i {xs=[]} = Refl
 indexConcatAsIndexAppended i {xs=x::xs} = indexConcatAsIndexAppended {xs=xs} i
 
-permDoesntFixAValueNotFixed : (sigma : Iso (Fin n) (Fin n)) -> (nel1, nel2 : Fin n) -> (runIso sigma nel1 = nel2) -> Either (Not (runIso sigma nel2 = nel2)) (nel1 = nel2)
-{-
--- Positive form. Not strong enough for our purposes.
-permpermFixedImpliesPermFixed : (sigma : Iso (Fin n) (Fin n)) -> (nel : Fin n) -> (runIso sigma nel = runIso sigma $ runIso sigma nel) -> (nel = runIso sigma nel2)
--}
-permDoesntFixAValueNotFixed (MkIso to from toFrom fromTo) nel1 nel2 nel1GoesTo2
-	with (decEq nel1 nel2)
-		| Yes pr = Right pr
-		| No prneq = Left $ \nel2GoesTo2 =>
-			prneq $ trans (sym $ fromTo nel1) $ flip trans (fromTo nel2)
-			$ cong {f=from} $ trans nel1GoesTo2 $ sym nel2GoesTo2
-{-
--- Alternatively, this form can be used with a (DecEq)-as-(Either) to remove the (with).
-		| No prneq = Left $ prneq
-			. ( trans (sym $ fromTo nel1) )
-			. ( flip trans (fromTo nel2) )
-			. ( cong {f=from} ) . ( trans nel1GoesTo2 ) . sym
--}
-
-permDoesntFix_corrolary : (sigma : Iso (Fin (S n)) (Fin (S n))) -> (snel : Fin (S n)) -> Not (snel = FZ) -> (runIso sigma snel = FZ) -> Not (runIso sigma FZ = FZ)
-permDoesntFix_corrolary sigma snel ab pr = runIso eitherBotRight $ map ab (permDoesntFixAValueNotFixed sigma snel FZ pr)
-
 splitFinFS : (i : Fin (S predn)) -> Either ( k : Fin predn ** i = FS k ) ( i = Fin.FZ {k=predn} )
 splitFinFS FZ = Right Refl
 splitFinFS (FS k) = Left (k ** Refl)
@@ -119,6 +97,30 @@ finReduceIsRight_sym : (z : Fin (S predn))
 	-> (pr : FZ {k=predn} = z ** Right pr = finReduce z)
 finReduceIsRight_sym FZ _ = (Refl ** Refl)
 finReduceIsRight_sym (FS k) pr = void $ FZNotFS $ sym pr
+
+
+
+permDoesntFixAValueNotFixed : (sigma : Iso (Fin n) (Fin n)) -> (nel1, nel2 : Fin n) -> (runIso sigma nel1 = nel2) -> Either (Not (runIso sigma nel2 = nel2)) (nel1 = nel2)
+{-
+-- Positive form. Not strong enough for our purposes.
+permpermFixedImpliesPermFixed : (sigma : Iso (Fin n) (Fin n)) -> (nel : Fin n) -> (runIso sigma nel = runIso sigma $ runIso sigma nel) -> (nel = runIso sigma nel2)
+-}
+permDoesntFixAValueNotFixed (MkIso to from toFrom fromTo) nel1 nel2 nel1GoesTo2
+	with (decEq nel1 nel2)
+		| Yes pr = Right pr
+		| No prneq = Left $ \nel2GoesTo2 =>
+			prneq $ trans (sym $ fromTo nel1) $ flip trans (fromTo nel2)
+			$ cong {f=from} $ trans nel1GoesTo2 $ sym nel2GoesTo2
+{-
+-- Alternatively, this form can be used with a (DecEq)-as-(Either) to remove the (with).
+		| No prneq = Left $ prneq
+			. ( trans (sym $ fromTo nel1) )
+			. ( flip trans (fromTo nel2) )
+			. ( cong {f=from} ) . ( trans nel1GoesTo2 ) . sym
+-}
+
+permDoesntFix_corrolary : (sigma : Iso (Fin (S n)) (Fin (S n))) -> (snel : Fin (S n)) -> Not (snel = FZ) -> (runIso sigma snel = FZ) -> Not (runIso sigma FZ = FZ)
+permDoesntFix_corrolary sigma snel ab pr = runIso eitherBotRight $ map ab (permDoesntFixAValueNotFixed sigma snel FZ pr)
 
 weakenIsoByValFZ : Iso (Fin (S n)) (Fin (S n)) -> Iso (Fin n) (Fin n)
 weakenIsoByValFZ {n} (MkIso to from toFrom fromTo) = MkIso to' from' toFrom' fromTo'

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -1169,7 +1169,9 @@ vecMatVecRebracketing : {l : Vect n ZZ}
 	-> {c : Matrix n m ZZ}
 	-> {r : Vect m ZZ}
 	-> l <:> (c</>r) = (l<\>c) <:> r
-vecMatVecRebracketing {l} {c} {r} {n} {m} = ?vecMatVecRebracketing_pr
+vecMatVecRebracketing {l} {c} {r} {n} {m} =
+	trans step1 $ trans step2 $ trans step3 $ trans step4 $ trans step5
+	$ sym $ trans step1s $ trans step2s $ step3s
 	where
 		-- (w/ timesVectMatAsLinearCombo)
 		-- sum_i $ l_i . (sum_j $ r_j <#> c*_j)_i
@@ -1414,64 +1416,6 @@ vecMatVecRebracketing {l} {c} {r} {n} {m} = ?vecMatVecRebracketing_pr
 		  exact rewrite indexFinsIsIndex {i=ii} in rewrite indexFinsIsIndex {i=jj} in Refl
 
 		-}
-		{-
-		-- This works, but we prefer to combine several steps into this one.
-		-- cong transposeIndexChariz & transposeIndicesChariz
-		-- sum_i $ sum_j $ l_i . (r_j . c_i_j)
-		step4 : monoidsum $ monoidsum
-				$ map (\j => map ( \i => index i l
-						<.> (index j r
-							<.> (indices j i $ transpose c)) )
-					$ fins n)
-				$ fins m
-			= monoidsum $ monoidsum
-				$ map (\j => map ( \i => index i l
-						<.> (index j r <.> indices i j c) )
-					$ fins n)
-				$ fins m
-		step4 = cong {f=(monoidsum {t=Vect n} {a=ZZ})
-				. (monoidsum {t=Vect m} {a=Vect n ZZ})}
-			$ vecIndexwiseEq
-			$ \jj => trans indexMapChariz
-				$ trans (cong {f=\jjj => flip map (fins n)
-						$ \iii => index iii l <.>
-							(index jjj r <.>
-								(indices jjj iii
-									$ transpose c))}
-					$ indexFinsIsIndex {i=jj})
-				$ trans (vecIndexwiseEq
-				$ \ii => trans indexMapChariz
-					$ trans (cong {f=\iii => index iii l <.>
-							(index jj r <.>
-								(indices jj iii
-									$ transpose c))}
-						$ indexFinsIsIndex {i=ii})
-					$ trans (cong {f=((index ii l)<.>)
-							. ((index jj r)<.>)}
-						$ transposeIndicesChariz ii jj {xs=c})
-					$ sym $ trans (indexMapChariz {k=ii})
-					$ cong {f=\iii => index iii l <.>
-						(index jj r <.> indices iii jj c)}
-					$ indexFinsIsIndex {i=ii}
-				) $ sym $ trans (indexMapChariz {k=jj})
-				$ cong {f=\jjj => flip map (fins n)
-					$ \iii => index iii l <.>
-						(index jjj r <.> indices iii jjj c)}
-				$ indexFinsIsIndex {i=jj}
-		-- Combined into step4_2
-		-- associativity of multiplication
-		-- sum_i $ sum_j $ (l_i . r_j) . c_i_j
-		step5 : monoidsum $ monoidsum
-				$ map (\j => map ( \i => index i l
-						<.> (index j r <.> indices i j c) )
-					$ fins n)
-				$ fins m
-			= monoidsum $ monoidsum
-				$ map (\j => map ( \i => index i l <.> index j r
-						<.> indices i j c )
-					$ fins n)
-				$ fins m
-		-}
 		-- 1) transposeIndicesChariz
 		-- sum_i $ sum_j $ l_i . (r_j . c_i_j)
 		-- 2) associativity of multiplication
@@ -1480,7 +1424,7 @@ vecMatVecRebracketing {l} {c} {r} {n} {m} = ?vecMatVecRebracketing_pr
 		-- sum_i $ sum_j $ (r_j . l_i) . c_i_j
 		-- 4) associativity multiplication
 		-- sum_i $ sum_j $ r_j . (l_i . c_i_j)
-		step4_2 : monoidsum $ monoidsum
+		step4 : monoidsum $ monoidsum
 				$ map (\j => map ( \i => index i l
 						<.> (index j r
 							<.> (indices j i $ transpose c)) )
@@ -1491,7 +1435,7 @@ vecMatVecRebracketing {l} {c} {r} {n} {m} = ?vecMatVecRebracketing_pr
 						<.> (index i l <.> indices i j c) )
 					$ fins n)
 				$ fins m
-		step4_2 = cong {f=(monoidsum {t=Vect n} {a=ZZ})
+		step4 = cong {f=(monoidsum {t=Vect n} {a=ZZ})
 				. (monoidsum {t=Vect m} {a=Vect n ZZ})}
 			--	UNPACK LAYERS (map, map, product) LEFT TO RIGHT	--
 			$ vecIndexwiseEq
@@ -1552,7 +1496,7 @@ vecMatVecRebracketing {l} {c} {r} {n} {m} = ?vecMatVecRebracketing_pr
 		-- generalized associativity law: (x+y)+(z+w)=(x+z)+(y+w);
 		-- 	monoidsum $ monoidsum xs = monoidsum $ monoidsum $ transpose xs
 		-- sum_j $ sum_i $ r_j . (l_i . c_i_j)
-		step6_2 : monoidsum $ monoidsum
+		step5 : monoidsum $ monoidsum
 				$ map (\j => map ( \i => index j r
 						<.> (index i l <.> indices i j c) )
 					$ fins n)
@@ -1584,38 +1528,6 @@ vecMatVecRebracketing {l} {c} {r} {n} {m} = ?vecMatVecRebracketing_pr
 							<.> (index i l <.> indices i j c) )
 					$ fins m)
 				$ fins n
-		{-
-		-- Combined into step4_2
-		-- associativity & commutativity of multiplication
-		-- sum_j $ sum_i $ (r_j . l_i) . c_i_j
-		-- sum_j $ sum_i $ (l_i . r_j) . c_i_j
-		step5s : monoidsum $ monoidsum
-				$ map (\i => map ( \j => index j r
-							<.> (index i l <.> indices i j c) )
-					$ fins m)
-				$ fins n
-			= monoidsum $ monoidsum
-				$ map (\i => map ( \j => index i l <.> index j r
-							<.> indices i j c )
-					$ fins m)
-				$ fins n
-		-- The transformation is moved to a different order, and before the (sym),
-		-- so the sides of the equation are swapped and the algebraic expr changed.
-		-- See step6_2.
-		-- generalized associativity law: (x+y)+(z+w)=(x+z)+(y+w);
-		-- 	monoidsum $ monoidsum xs = monoidsum $ monoidsum $ transpose xs
-		-- sum_i $ sum_j $ (l_i . r_j) <.> c_i_j
-		step6 : monoidsum $ monoidsum
-				$ map (\i => map ( \j => index i l <.> index j r
-							<.> indices i j c )
-					$ fins m)
-				$ fins n
-			= monoidsum $ monoidsum
-				$ map (\j => map ( \i => index i l <.> index j r
-							<.> indices i j c )
-					$ fins n)
-				$ fins m
-		-}
 
 {-
 vecMatVecRebracketing {l=[]} {c=[]} {r} = sym

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -1227,14 +1227,14 @@ vecMatVecRebracketing {l} {c} {r} {n} {m} =
 								<.> (indices
 									(index jj $ fins m)
 									ind
-								$ transpose c))}
+									$ transpose c))}
 							$ indexFinsIsIndex {i=ii}
 						) $ cong {f=((index ii l)<.>)}
 						$ trans (cong {f=(<.>(indices
 									(index jj $ fins m)
 									ii
-								$ transpose c))
-							. (flip index r)}
+									$ transpose c))
+								. (flip index r)}
 							$ indexFinsIsIndex {i=jj})
 						$ cong {f=((index jj r)<.>)
 							. (index ii)
@@ -1493,6 +1493,7 @@ vecMatVecRebracketing {l} {c} {r} {n} {m} =
 					$ \iii => index jjj r <.>
 						(index iii l <.> indices iii jjj c)}
 				$ indexFinsIsIndex {i=jj}
+		-- Exchanging the order of summation.
 		-- generalized associativity law: (x+y)+(z+w)=(x+z)+(y+w);
 		-- 	monoidsum $ monoidsum xs = monoidsum $ monoidsum $ transpose xs
 		-- sum_j $ sum_i $ r_j . (l_i . c_i_j)
@@ -1528,6 +1529,52 @@ vecMatVecRebracketing {l} {c} {r} {n} {m} =
 							<.> (index i l <.> indices i j c) )
 					$ fins m)
 				$ fins n
+		-- Takes the implementation of (step3) and exchanges the roles of
+		-- n and m; l and r; ii and jj; (transpose c) and (c).
+		{-
+		Without the implicit args filled for each (monoidsum), there are not
+		enough helpful error msgs about missing implicits to find a solution.
+		-}
+		step3s = cong {f=(monoidsum {t=Vect m} {a=ZZ})
+				. (monoidsum {t=Vect n} {a=Vect m ZZ})}
+			$ vecIndexwiseEq
+			$ \ii => trans (indexMapChariz {f=zipWith (<.>) r})
+				$ trans (
+				trans (cong $ zipWithEntryChariz
+						{m=(<#>) {a=ZZ} {b=Vect m ZZ}})
+					$ vecIndexwiseEq
+					$ \jj => trans (zipWithEntryChariz {m=(<.>) {a=ZZ}})
+						$ trans (cong {f=((index jj r)<.>)}
+							$ indexMapChariz)
+						$ sym $ trans indexMapChariz
+						{-
+						$ rewrite indexFinsIsIndex {i=jj}
+						in rewrite indexFinsIsIndex {i=ii} in Refl
+						-- fails, so the following instead.
+						-}
+						$ trans (cong
+							-- Elaborating upon
+							-- {f=(<.>_) . (flip index r)}
+							{f=\ind => index ind r
+							<.>(index (index ii $ fins n) l
+								<.> (indices
+									(index ii $ fins n)
+									ind
+									c))}
+							$ indexFinsIsIndex {i=jj}
+						) $ cong {f=((index jj r)<.>)}
+						$ trans (cong {f=(<.>(indices
+									(index ii $ fins n)
+									jj
+									c))
+								. (flip index l)}
+							$ indexFinsIsIndex {i=ii})
+						$ cong {f=((index ii l)<.>)
+							. (index jj)
+							. (flip index c)}
+							$ indexFinsIsIndex {i=ii}
+				)
+				$ sym indexMapChariz
 
 -- but probably (VerifiedCommutativeRing a)
 timesMatMatIsAssociative : {l : Matrix _ _ ZZ} -> {c : Matrix _ _ ZZ} -> {r : Matrix _ _ ZZ}

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -1474,31 +1474,7 @@ updateAtEquality {ls=[]} updi f fnpreq = FinZElim updi
 updateAtEquality {ls=l::ls} {rs} FZ f fnpreq = vecHeadtailsEq {xs=tail $ (l::ls) `zippyScale` rs} ( trans (sym $ timesVectMatAsLinearCombo (f _ l) rs) $ trans (fnpreq l) $ cong {f=f _} $ timesVectMatAsLinearCombo l rs ) Refl
 updateAtEquality {ls=l::ls} (FS penupdi) f fnpreq = vecHeadtailsEq Refl $ updateAtEquality penupdi f fnpreq
 
--- Note the relationship to bilinearity of matrix multiplication
-vectMatLScalingCompatibility : {z : ZZ} -> {rs : Matrix k m ZZ} -> (z <#> la) <\> rs = z <#> (la <\> rs)
-vectMatLScalingCompatibility {z} {la} {rs} = ?vectMatLScalingCompatibility_rhs
 
-{-
--- Works in REPL, untested otherwise
-vectMatLScalingCompatibility_rhs = proof
-  intros
-  claim vectmatLiftId1 (z <#> la) <\> rs = head $ (row $ z <#> la) <> rs
-  unfocus
-  claim moveScaleOutsideRow row (z <#> la) = z <#> (row la)
-  unfocus
-  claim chScaleOutsideTimes (row (z <#> la)) <> rs = z <#> ((row la) <> rs)
-  unfocus
-  exact trans vectmatLiftId1 $ cong {f=head} chScaleOutsideTimes
-  trivial
-  unfocus
-  exact trans (cong {f=(<> rs)} moveScaleOutsideRow) _
-  trivial
-  compute
-  claim scalMatMatCompat (scal : ZZ) -> {nu, ka, mu : Nat} -> (xs : Matrix nu ka ZZ) -> (ys : Matrix ka mu ZZ) -> (scal <#> xs) <> ys = scal <#> (xs <> ys)
-  unfocus
-  exact scalMatMatCompat z (row la) rs
-  exact ?timesScalarLeftCommutesWithTimesMatRight
--}
 
 spanRowScalelz : (z : ZZ) -> (updi : Fin n') -> spanslz xs ys -> spanslz xs (updateAt updi (z<#>) ys)
 spanRowScalelz z updi (vs ** prvs) {xs} = (updateAt updi (z<#>) vs ** trans scaleMain $ rewrite sym prvs in Refl)
@@ -1509,6 +1485,11 @@ spanRowScalelz z updi (vs ** prvs) {xs} = (updateAt updi (z<#>) vs ** trans scal
 
 
 spanScalelz : (z : ZZ) -> spanslz xs ys -> spanslz xs (z<#>ys)
+spanScalelz z {ys} spXY = spanslztrans spXY
+	$ ( z<#>Id **
+	trans (sym $ timesMatMatAsMultipleLinearCombos (z<#>Id) ys)
+	$ trans (matMatLScalingCompatibility z Id ys)
+	$ cong {f=(z<#>)} $ multIdLeftNeutral ys )
 
 spanAdd : spanslz xs ys -> spanslz xs zs -> spanslz xs (ys <+> zs)
 spanAdd {xs} {ys} {zs} spXY spXZ = ((getWitness spXY)<+>(getWitness spXZ) **

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -1056,20 +1056,6 @@ multIdRightNeutral a = vecIndexwiseEq $ \i =>
 			-- = index i a <:> basis j
 		$ dotBasisRIsIndex $ index i a
 
-{-
-When checking type of ZZModuleSpan.negScalarToScaledNeg:
-When checking an application of function Control.Algebra.VectorSpace.<#>:
-        Can't resolve type class Group r
-
----
-
-negScalarToScaledNeg : (VerifiedRingWithUnity r, VerifiedModule r a) -> (s : r) -> (x : a) -> (inverse s) <#> x = s <#> (inverse x)
--}
-
-negScalarToScaledNegVect : VerifiedRingWithUnity r => (s : r) -> (x : Vect _ r) -> (inverse s) <#> x = s <#> (inverse x)
-
-negScalarToScaledNegMat : VerifiedRingWithUnity r => (s : r) -> (x : Matrix _ _ r) -> (inverse s) <#> x = s <#> (inverse x)
-
 rewriteAssociativityUnderEquality : {f, g : a -> a -> a} -> ( (x : a) -> (y : a) -> f x y = g x y) -> (l `f` (c `f` r) = (l `f` c) `f` r) -> (l `g` (c `g` r) = (l `g` c) `g` r)
 rewriteAssociativityUnderEquality {f} {g} {l} {c} {r} fneq prf = trans (sym stepleft) $ trans prf stepright
 	where
@@ -1507,7 +1493,7 @@ spanSub' = proof
   let spanAdd' = spanAdd {xs=xs} {ys=ys} {zs = inverse zs}
   refine spanAdd'
   exact prxy
-  exact spanslztrans (spanScalelz (inverse unity) prxz) $ replace {P=\t => spanslz ((<#>) (inverse $ unity {a=ZZ}) zs) t} (trans ( negScalarToScaledNegMat (unity {a=ZZ}) zs ) ( moduleScalarUnityIsUnity {a=ZZ} (inverse zs) )) spanslzrefl
+  exact spanslztrans (spanScalelz (inverse unity) prxz) $ replace {P=\t => spanslz ((<#>) (inverse $ unity {a=ZZ}) zs) t} (trans ( negScalarToScaledNegMat_zz (unity {a=ZZ}) zs ) ( moduleScalarUnityIsUnity {a=ZZ} (inverse zs) )) spanslzrefl
 
 {-
 -- Works in REPL only
@@ -1516,7 +1502,7 @@ spanSub' = proof
   refine spanAdd
   exact prxy
   exact spanslztrans (spanScalelz (inverse unity) prxz) _
-  exact replace {P=\t => spanslz ((<#>) (inverse $ unity {a=ZZ}) zs) t} (trans ( negScalarToScaledNegMat (unity {a=ZZ}) zs ) ( the ((<#>) (unity {a=ZZ}) (inverse zs) = (inverse zs)) ?moduleIdScalZZ )) spanslzrefl
+  exact replace {P=\t => spanslz ((<#>) (inverse $ unity {a=ZZ}) zs) t} (trans ( negScalarToScaledNegMat_zz (unity {a=ZZ}) zs ) ( the ((<#>) (unity {a=ZZ}) (inverse zs) = (inverse zs)) ?moduleIdScalZZ )) spanslzrefl
 -}
 
 {-
@@ -1527,7 +1513,7 @@ spanSub' = proof
 spanSub : spanslz xs ys -> spanslz xs zs -> spanslz xs (ys <-> zs)
 spanSub {xs} {ys} {zs} prxy prxz
 	with ( spanAdd {xs=xs} {ys=ys} {zs = (inverse unity)<#>zs} prxy (spanScalelz (inverse unity) prxz) )
-		| (vs ** pr) = (vs ** cong {f=spanslz xs} $ negScalarToScaledNegMat unity zs)
+		| (vs ** pr) = (vs ** cong {f=spanslz xs} $ negScalarToScaledNegMat_zz unity zs)
 
 
 -- Replacement test code for analyzing the problem:
@@ -1538,7 +1524,7 @@ spanSub {xs} {ys} {zs} {n} {n'} {w} prxy prxz
 	with (?akdjna)
 	-- with ( spanAdd {xs=xs} {ys=ys} {zs = (inverse (the ZZ unity))<#>zs} prxy (spanScalelz (inverse (the ZZ unity)) prxz) )
 		| (vs ** pr) = ?ajdnjfka
-		-- | (vs ** pr) = (vs ** cong {f=spanslz xs} $ negScalarToScaledNegMat (the ZZ unity) pr)
+		-- | (vs ** pr) = (vs ** cong {f=spanslz xs} $ negScalarToScaledNegMat_zz (the ZZ unity) pr)
 -}
 
 

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -501,18 +501,18 @@ multIdRightNeutral a = vecIndexwiseEq $ \i =>
 		$ dotBasisRIsIndex $ index i a
 
 {-
-When checking type of ZZModuleSpan.rewriteMultInv:
+When checking type of ZZModuleSpan.negScalarToScaledNeg:
 When checking an application of function Control.Algebra.VectorSpace.<#>:
         Can't resolve type class Group r
 
 ---
 
-rewriteMultInv : (VerifiedRingWithUnity r, VerifiedModule r a) -> (s : r) -> (x : a) -> (inverse s) <#> x = s <#> (inverse x)
+negScalarToScaledNeg : (VerifiedRingWithUnity r, VerifiedModule r a) -> (s : r) -> (x : a) -> (inverse s) <#> x = s <#> (inverse x)
 -}
 
-rewriteMultInvVect : VerifiedRingWithUnity r => (s : r) -> (x : Vect _ r) -> (inverse s) <#> x = s <#> (inverse x)
+negScalarToScaledNegVect : VerifiedRingWithUnity r => (s : r) -> (x : Vect _ r) -> (inverse s) <#> x = s <#> (inverse x)
 
-rewriteMultInvMat : VerifiedRingWithUnity r => (s : r) -> (x : Matrix _ _ r) -> (inverse s) <#> x = s <#> (inverse x)
+negScalarToScaledNegMat : VerifiedRingWithUnity r => (s : r) -> (x : Matrix _ _ r) -> (inverse s) <#> x = s <#> (inverse x)
 
 rewriteAssociativityUnderEquality : {f, g : a -> a -> a} -> ( (x : a) -> (y : a) -> f x y = g x y) -> (l `f` (c `f` r) = (l `f` c) `f` r) -> (l `g` (c `g` r) = (l `g` c) `g` r)
 rewriteAssociativityUnderEquality {f} {g} {l} {c} {r} fneq prf = trans (sym stepleft) $ trans prf stepright
@@ -970,7 +970,7 @@ spanSub' = proof
   let spanAdd' = spanAdd {xs=xs} {ys=ys} {zs = inverse zs}
   refine spanAdd'
   exact prxy
-  exact spanslztrans (spanScalelz (inverse unity) prxz) $ replace {P=\t => spanslz ((<#>) (inverse $ unity {a=ZZ}) zs) t} (trans ( rewriteMultInvMat (unity {a=ZZ}) zs ) ( moduleScalarUnityIsUnity {a=ZZ} (inverse zs) )) spanslzrefl
+  exact spanslztrans (spanScalelz (inverse unity) prxz) $ replace {P=\t => spanslz ((<#>) (inverse $ unity {a=ZZ}) zs) t} (trans ( negScalarToScaledNegMat (unity {a=ZZ}) zs ) ( moduleScalarUnityIsUnity {a=ZZ} (inverse zs) )) spanslzrefl
 
 {-
 -- Works in REPL only
@@ -979,7 +979,7 @@ spanSub' = proof
   refine spanAdd
   exact prxy
   exact spanslztrans (spanScalelz (inverse unity) prxz) _
-  exact replace {P=\t => spanslz ((<#>) (inverse $ unity {a=ZZ}) zs) t} (trans ( rewriteMultInvMat (unity {a=ZZ}) zs ) ( the ((<#>) (unity {a=ZZ}) (inverse zs) = (inverse zs)) ?moduleIdScalZZ )) spanslzrefl
+  exact replace {P=\t => spanslz ((<#>) (inverse $ unity {a=ZZ}) zs) t} (trans ( negScalarToScaledNegMat (unity {a=ZZ}) zs ) ( the ((<#>) (unity {a=ZZ}) (inverse zs) = (inverse zs)) ?moduleIdScalZZ )) spanslzrefl
 -}
 
 {-
@@ -990,7 +990,7 @@ spanSub' = proof
 spanSub : spanslz xs ys -> spanslz xs zs -> spanslz xs (ys <-> zs)
 spanSub {xs} {ys} {zs} prxy prxz
 	with ( spanAdd {xs=xs} {ys=ys} {zs = (inverse unity)<#>zs} prxy (spanScalelz (inverse unity) prxz) )
-		| (vs ** pr) = (vs ** cong {f=spanslz xs} $ rewriteMultInvMat unity zs)
+		| (vs ** pr) = (vs ** cong {f=spanslz xs} $ negScalarToScaledNegMat unity zs)
 
 
 -- Replacement test code for analyzing the problem:
@@ -1001,7 +1001,7 @@ spanSub {xs} {ys} {zs} {n} {n'} {w} prxy prxz
 	with (?akdjna)
 	-- with ( spanAdd {xs=xs} {ys=ys} {zs = (inverse (the ZZ unity))<#>zs} prxy (spanScalelz (inverse (the ZZ unity)) prxz) )
 		| (vs ** pr) = ?ajdnjfka
-		-- | (vs ** pr) = (vs ** cong {f=spanslz xs} $ rewriteMultInvMat (the ZZ unity) pr)
+		-- | (vs ** pr) = (vs ** cong {f=spanslz xs} $ negScalarToScaledNegMat (the ZZ unity) pr)
 -}
 
 

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -1962,10 +1962,13 @@ zippyScale vs xs = map (\zs => monoidsum $ zipWith (<#>) zs xs) vs
 
 -- Inherited properties from (<>) equality proven in Data.Matrix.LinearCombinations
 zippyScaleIsAssociative : l `zippyScale` (c `zippyScale` r) = (l `zippyScale` c) `zippyScale` r
-{-
-zippyScaleIsAssociative = ?zippyScaleIsAssociative'
--- zippyScaleIsAssociative = rewriteAssociativityUnderEquality timesMatMatAsMultipleLinearCombos
--}
+zippyScaleIsAssociative {l} {c} {r} =
+	trans (sym $ timesMatMatAsMultipleLinearCombos l $ c `zippyScale` r)
+	$ trans (cong {f=(l<>)} $ sym $ timesMatMatAsMultipleLinearCombos c r)
+	$ trans timesMatMatIsAssociative
+	$ trans (cong {f=(<>r)} $ timesMatMatAsMultipleLinearCombos l c)
+	$ timesMatMatAsMultipleLinearCombos (l `zippyScale` c) r
+
 zippyScaleIsAssociative_squaremats : {l, c, r : Matrix n n ZZ} -> l `zippyScale` (c `zippyScale` r) = (l `zippyScale` c) `zippyScale` r
 -- zippyScaleIsAssociative_squaremats = ?zippyScaleIsAssociative_squaremats'
 zippyScaleIsAssociative_squaremats {l} {c} {r} {n} = ( rewriteAssociativityUnderEquality {l=l} {c=c} {r=r} {f=(<>)} {g=\varg => \xarg => map (\zs => monoidsum (zipWith (<#>) zs xarg)) varg} (timesMatMatAsMultipleLinearCombos {n'=n} {n=n} {w=n}) ) $ timesMatMatIsAssociative {l=l} {c=c} {r=r}

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -1529,49 +1529,6 @@ vecMatVecRebracketing {l} {c} {r} {n} {m} =
 					$ fins m)
 				$ fins n
 
-{-
-vecMatVecRebracketing {l=[]} {c=[]} {r} = sym
-	$ trans (cong {f=(<:>r)} zippyLemA)
-	$ neutralVectIsDotProductZero_L r
-vecMatVecRebracketing {l=l::ls} {c=c::cs} {r=r::rs} = ?vecMatVecRebracketing_pr
-{-
-	trans (dotproductRewrite {v=l::ls} {w=(c::cs)</>(r::rs)})
--- > exact trans (dotproductRewrite {v=l1::ls} {w=(c1::cs)</>(r1::rs)}) $ _
-	$ trans monoidrec1D
--- > exact trans monoidrec1D $ _
-	$ trans (cong {f=(( l<.>((r::rs)<:>c) )<+>)}
-		$ trans (sym $ dotproductRewrite {v=ls} {w=cs</>(r::rs)})
-		$ trans (vecMatVecRebracketing {l=ls} {c=cs} {r=r::rs})
-		$ dotproductRewrite {v=ls<\>cs} {w=r::rs})
-{-
-> claim reclem (l : Vect _ ZZ) -> (c : Matrix _ _ ZZ) -> (r : Vect _ ZZ) -> l <:> (c</>r) = (l<\>c) <:> r
-> exact trans (cong {f=(( l1<.>((r1::rs)<:>c1) )<+>)} $ trans (sym $ dotproductRewrite {v=ls} {w=cs</>(r1::rs)}) $ trans (reclem ls cs (r1::rs)) $ dotproductRewrite {v=ls<\>cs} {w=r1::rs}) $ _
--}
-	$ trans (cong {f=(<+>( monoidsum
-			$ zipWith (<.>) (ls<\>cs) (r::rs) ))}
-		$ ?vecMatVecRebracketing_p1)
-----
-	$ trans (sym monoidrec1D)
-	-- monoidsum $ _ :: zipWith (<.>) (ls<\>cs) (r::rs)
-	-- timesVectMatAsLinearCombo
-	-- timesVectMatAsHeadTail_ByTransposeElimination
-	$ ?vecMatVecRebracketing_p2
-----
-	$ sym
-	$ trans (dotproductRewrite {v=(l::ls)<\>(c::cs)} {w=r::rs})
-	$ monoidrec1D
--}
--- timesVectMatAsHeadTail_ByTransposeElimination
--- timesVectMatAsLinearCombo
--- neutralVectIsVectTimesZero
--- neutralMatIsMultZeroL
--- neutralVectIsDotProductZero_R
-vecMatVecRebracketing {l} {c} {r=[]} =
-	trans (cong {f=(l<:>)} $ emptyVectIsTimesVectZero c)
-	$ trans (neutralVectIsDotProductZero_R l)
-	$ sym $ neutralVectIsDotProductZero_R (l<\>c)
--}
-
 -- but probably (VerifiedCommutativeRing a)
 timesMatMatIsAssociative : {l : Matrix _ _ ZZ} -> {c : Matrix _ _ ZZ} -> {r : Matrix _ _ ZZ}
 	-> l <> (c <> r) = (l <> c) <> r

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -26,6 +26,9 @@ Trivial lemmas and plumbing
 runIso : Iso a b -> a -> b
 runIso (MkIso to _ _ _) = to
 
+runIsoTrans : runIso (isoTrans sigma tau) x = runIso tau $ runIso sigma x
+runIsoTrans {sigma=MkIso to _ _ _} {tau=MkIso to' _ _ _} = Refl
+
 total
 indexRangeIsIndex : index i Vect.range = i
 indexRangeIsIndex {i=FZ} = Refl
@@ -293,7 +296,13 @@ vectPermToIndexChariz {sigma=sigma@(MkIso to _ _ _)} {xs} {i} = trans indexMapCh
 vectPermToRefl : vectPermTo Isomorphism.isoRefl xs = xs
 vectPermToRefl = vecIndexwiseEq $ \i => vectPermToIndexChariz {sigma=isoRefl}
 
-vectPermToTrans : vectPermTo (isoTrans sigma tau) xs = vectPermTo tau $ vectPermTo sigma xs
+vectPermToTrans : vectPermTo (isoTrans sigma tau) xs = vectPermTo sigma $ vectPermTo tau xs
+vectPermToTrans {sigma} {tau} {xs} = vecIndexwiseEq $ \i =>
+	trans vectPermToIndexChariz
+	$ sym
+	$ trans vectPermToIndexChariz
+	$ trans vectPermToIndexChariz
+	$ cong {f=flip index xs} $ sym $ runIsoTrans {sigma=sigma} {tau=tau} {x=i}
 
 {-
 -- (1/2) Section discusses a system for permuting (xs++ys) to (ys++xs).
@@ -628,6 +637,15 @@ rotateAt {predn} nel = ( sigma
 {-
 -- (2/2) Section discusses a system for permuting (xs++ys) to (ys++xs).
 -- Requires (permThroughFSInConcat) to replace (permThroughFS).
+
+!!!!!!!!
+Uses incorrect definition of (vectPermToTrans):
+
+vectPermToTrans : vectPermTo (isoTrans sigma tau) xs = vectPermTo tau $ vectPermTo sigma xs
+
+The fact is, vectPermTo (isoTrans sigma tau) xs = vectPermTo sigma $ vectPermTo tau xs
+!!!!!!!!
+
 
 nullAppendId : (xs : Vect n a) -> xs++[] ~=~ xs
 nullAppendId [] = Refl

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -296,7 +296,7 @@ vectPermToRefl = vecIndexwiseEq $ \i => vectPermToIndexChariz {sigma=isoRefl}
 vectPermToTrans : vectPermTo (isoTrans sigma tau) xs = vectPermTo tau $ vectPermTo sigma xs
 
 {-
--- Section discusses a system for permuting (xs++ys) to (ys++xs).
+-- (1/2) Section discusses a system for permuting (xs++ys) to (ys++xs).
 
 ||| See (FSAtConcatChariz).
 FSAtConcat : (n, m : Nat) -> Fin (n+m) -> Fin (n+(S m))
@@ -626,7 +626,7 @@ rotateAt {predn} nel = ( sigma
 
 
 {-
--- Section discusses a system for permuting (xs++ys) to (ys++xs).
+-- (2/2) Section discusses a system for permuting (xs++ys) to (ys++xs).
 -- Requires (permThroughFSInConcat) to replace (permThroughFS).
 
 nullAppendId : (xs : Vect n a) -> xs++[] ~=~ xs

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -1427,6 +1427,35 @@ vecMatVecRebracketing {l} {c} {r} {n} {m} = ?vecMatVecRebracketing_pr
 						<.> (index j r <.> indices i j c) )
 					$ fins n)
 				$ fins m
+		step4 = cong {f=(monoidsum {t=Vect n} {a=ZZ})
+				. (monoidsum {t=Vect m} {a=Vect n ZZ})}
+			$ vecIndexwiseEq
+			$ \jj => trans indexMapChariz
+				$ trans (cong {f=\jjj => flip map (fins n)
+						$ \iii => index iii l <.>
+							(index jjj r <.>
+								(indices jjj iii
+									$ transpose c))}
+					$ indexFinsIsIndex {i=jj})
+				$ trans (vecIndexwiseEq
+				$ \ii => trans indexMapChariz
+					$ trans (cong {f=\iii => index iii l <.>
+							(index jj r <.>
+								(indices jj iii
+									$ transpose c))}
+						$ indexFinsIsIndex {i=ii})
+					$ trans (cong {f=((index ii l)<.>)
+							. ((index jj r)<.>)}
+						$ transposeIndicesChariz ii jj {xs=c})
+					$ sym $ trans (indexMapChariz {k=ii})
+					$ cong {f=\iii => index iii l <.>
+						(index jj r <.> indices iii jj c)}
+					$ indexFinsIsIndex {i=ii}
+				) $ sym $ trans (indexMapChariz {k=jj})
+				$ cong {f=\jjj => flip map (fins n)
+					$ \iii => index iii l <.>
+						(index jjj r <.> indices iii jjj c)}
+				$ indexFinsIsIndex {i=jj}
 		-- associativity of multiplication
 		-- sum_i $ sum_j $ (l_i . r_j) . c_i_j
 		step5 : monoidsum $ monoidsum


### PR DESCRIPTION
All holes filled except `spanslpr`, which will be removed before the first release. Some holes remain from dependencies, namely the ones talked about in the issues. Remodularization will have to be done, and documentation (README) is highly outdated.
