### PR TITLE
ZZModuleSpan work - Update docs & complete

### DIFF
--- a/Data/Matrix/LinearCombinations.idr
+++ b/Data/Matrix/LinearCombinations.idr
@@ -539,10 +539,10 @@ timesMatMatAsMultipleLinearCombos' = proof
 
 
 {-
-* Prove the dot product is a bilinear map from (ZZ)-(Vect)s to (ZZ).
-* Prove ZZ matrices form a ring (should work for any ring).
+* Prove the dot product is a bilinear map from (ZZ)-(Vect)s to (ZZ) (or at least, up to symmetry in the arguments).
+* Prove ZZ matrices form an algebra. Should work for ring. Proof it's a ring follows from associativity of matrix multiplication for a commutative ground ring.
 * Distributivities of matrix-matrix, vector-matrix, and matrix-vector multiplication over matrix addition and vector addition.
-* Prove transposition is an antiendomorphism of multiplication and an endomorphism of addition, hence an antiendomorphism of the matrix ring.
+* Prove transposition is an antiendomorphism of multiplication for ZZ matrices, and an endomorphism of addition, hence an antiendomorphism of the matrix ring.
 * Some Algebra.neutral is a zero element proofs.
 * Prove scalar multiplication of the left factor in a vector- or matrix-matrix product
 is the same as multiplying the product by the same scalar. (Note rel. to bilinearity)

--- a/README.md
+++ b/README.md
@@ -210,3 +210,42 @@ Proved:
 Declared:
 * `zzVecNeutralIsNeutralL`/...`R` — the zero vector is an identity for vector addition. Overlaps w/ `monoidNeutralIsNeutralL_Vect` in Data.Matrix.AlgebraicVerified.
 * `zzVecScalarUnityIsUnity` — scalar multiplication of a `Vect _ ZZ` by `1` yields the original vector. Overlaps w/ `moduleScalarUnityIsUnity_Vect` in Data.Matrix.AlgebraicVerified.
+
+## Data.Vect.Structural
+
+A library of properties to do w/ `Vect`s as a structure and functions to/from them, including characterizations of those operations' effects structurally.
+
+* Theorem `vecHeadtailsEq` for proving equality of `Vect`s by proving equality of their heads and tails. Often used after `headtails`.
+* Theorem `vecIndexwiseEq` for proving equality of `Vect`s by proving indexwise equality of their entries.
+
+* Theorems characterizing `Vect`s of degenerate qualities.
+* Theorems characterizing the index or head of a `Vect` created with a certain operation.
+* The theorem `weakenedInd` about comparing an index of a list to an index of its `init`.
+* The theorem `extensionalEqToMapEq` extending an extensional equality between functions to one between their `map`s over `Vect`s.
+* `composeUnderMap` w/c proves preservation of function composition for `Vect _`, what would be `functorComposition` in a `VerifiedFunctor` instance.
+
+* Compatibility between the operations of the ring (a) and of (Vect n a) as a module under (index).
+
+* `foldrImplRec` — The recursive equation for (foldr) over (Vect)s. Converts a right fold into a left fold.
+* `monoidrec : Monoid a => (v : a) -> (vs : Vect n a) -> sum' (v::vs) = v <+> sum' vs` — The recursive equation for sums in (Monoid)s over a (Vect _). Converts a right fold into a left fold.
+	* See `monoidrec1D`/...`2D` elsewhere.
+
+## Data.Matrix.Structural
+
+A library of properties to do w/ `Matrix`s as a structure and functions to/from them, including characterizations of those operations' effects structurally.
+
+* `transposeIsInvolution : transpose $ transpose xs = xs`
+* `transposeIndicesChariz : {xs : Matrix n m a} -> (i : Fin n) -> (j : Fin m) -> indices j i $ transpose xs = indices i j xs`
+* `transposeIndexChariz : {xs : Matrix n m a} -> index k $ transpose xs = getCol k xs`
+	* `transposeNHead: head $ transpose xs = map head xs`
+* `transposeNTail : transpose $ tail $ transpose xs = map tail xs`
+	* See also: `transposeNTail2` elsewhere
+
+* `vecMatMultIsTransposeVecMult`/`matVecIsVecTransposeMult` — The special cases of the transpose being an anti-endomorphism of matrix multiplication for vector-matrix and matrix-vector multiplication.
+* `headVecMatMultChariz` — a vector-matrix product as mapped dot product lemma.
+
+* `matMultIndicesChariz : Ring a => {l : Matrix _ _ a} -> {r : Matrix _ _ a} -> indices i j (l<>r) = (index i l)<:>(getCol j r)` — the entrywise expression of a matrix product.
+
+* `leadingElemExtensionAsZipWithCons : map (r::) xs = Vect.zipWith Vect.(::) (replicate _ r) xs`
+	* `leadingElemExtensionFirstColReplicate`/`leadingElemExtensionColFSId` — the columns of `map (r::) xs`. Special cases of `map` being a `VerifiedFunctor`.
+* `nullcolExtensionEq` — If the first column of `xs` is the zero vector, then `xs` is the appension of `0` to each of its rows' `tail`s.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Foundational - algebraic:
 * `monoidsumNeutralIsNeutral1D`/...`2D` — The sum over the zero vector is zero, the sum over the zero matrix is the zero vector.
 * `sumTransposeMapRelation : (xs : Matrix n m ZZ) -> monoidsum $ transpose xs = map monoidsum xs` — view summing the transpose's row vectors together pointwise as replacing each of the original matrix's rows with their sum.
 * ```orderOfSummationExchange : (xs : Matrix n m ZZ)
-	-> monoidsum $ monoidsum xs = monoidsum $ monoidsum $ transpose xs``` — exchanging/interchanging the order of summation / of two iterated sums / of a double sum. Statement for iterated sums of the generalized associativity law (_x_ \+ _y_) \+ (_z_ \+ _w_)=(_x_ \+ _z_) \+ (_y_ \+ _w_).
+	-> monoidsum $ monoidsum xs = monoidsum $ monoidsum $ transpose xs``` — exchanging/interchanging the order of summation / of two iterated sums / of a double sum. Statement for iterated sums of the generalized associativity-commutativity law (_x_ \+ _y_) \+ (_z_ \+ _w_)=(_x_ \+ _z_) \+ (_y_ \+ _w_). See: `doubleSumInnerSwap`.
 	* ```sumSumAsSumMapSum : (xs : Matrix n m ZZ)
 	-> monoidsum $ map monoidsum xs = monoidsum $ monoidsum xs``` — equivalent to the above.
 
@@ -165,8 +165,34 @@ runIso (MkIso to _ _ _) = to```
 ## Data.Matrix.LinearCombinations
 
 Most significant contents:
-* Proof, from some unproved basic facts, of definition of vector-matrix multiplication as a linear combination where the vectors under combination are rows of the matrix and the scalar weights are the entries of the same index to the vector under multiplication. `timesVectMatAsLinearCombo : (v : Vect n ZZ) -> (xs : Matrix n w ZZ) -> ( v <\> xs = monoidsum (zipWith (<#>) v xs) )`.
+* Proof of definition of vector-matrix multiplication as a linear combination where the vectors under combination are rows of the matrix and the scalar weights are the entries of the same index to the vector under multiplication. `timesVectMatAsLinearCombo : (v : Vect n ZZ) -> (xs : Matrix n w ZZ) -> ( v <\> xs = monoidsum (zipWith (<#>) v xs) )`.
 * Proof from the above that the definition of matrix multiplication reduces to independent linear combinations of the row vectors of the righthand matrix. `timesMatMatAsMultipleLinearCombos : (vs : Matrix (S n') n ZZ) -> (xs : Matrix n w ZZ) -> vs <> xs = map (\zs => monoidsum $ zipWith (<#>) zs xs) vs`.
+* Material characterizing iterated summation `monoidsum`, such as `monoidrec1D`/...`2D`, `headOfSumIsSumOfHeads`, `tailOfSumIsSumOfTails`, `dotproductRewrite`.
+* `transposeNTail2`, which helps characterize the transpose.
+* Algebraic identities proved about matrices and vectors.
+	* The dot product is a bilinear map from (ZZ)-(Vect)s to (ZZ) (or at least, proof up to left-right symmetry).
+		* Scalar multiplication of the left factor in a vector- or matrix-matrix product is the same as multiplying the product by the same scalar. (Note rel. to bilinearity)
+	* ZZ matrices form an algebra. Uses `moduleScalarUnityIsUnity`. See also: `multIdLeftNeutral`, `multIdRightNeutral`, `timesMatMatIsAssociative` in ZZModuleSpan.
+	* Distributivities of matrix-matrix, vector-matrix, and matrix-vector multiplication over matrix addition and vector addition.
+	* Transposition is an antiendomorphism of multiplication for a commutative ground ring and an endomorphism of addition, hence an antiendomorphism of the matrix ring.
+	* Some Algebra.neutral is a zero element / scalar zero proofs.
+		* `dotCancelsHeadWithLeadingZeroL : (x, y : Vect n ZZ) -> (Algebra.neutral::x)<:>(r::y) = x<:>y`/...`R` — a consequence
+		* `matMultCancelsHeadWithZeroColExtensionL : (map ((Pos 0)::) xs)<>(z::ys) = xs<>ys` — a consequence
+		* `timesPreservesLeadingZeroExtensionR : xs<>(map ((Pos 0)::) ys) = map ((Pos 0)::) $ xs<>ys` — a consequence
+	* `dotProductCommutative : (x, y : Vect n ZZ) -> x<:>y = y<:>x`
+	* The behavior & compatibility of the inverse w/ scalar multiplication of `Vect`s or `Matrix`s.
+
+Additional algebraic:
+* `doubleSumInnerSwap : VerifiedAbelianGroup t => (a, b, c, d : t) -> (a<+>b)<+>(c<+>d) = (a<+>c)<+>(b<+>d)` — a generalized associativity-commutativity law.
+** `doubleSumInnerSwap_Vect`
+
+Structural:
+* `lemma_VectAddEntrywise : .{n : Nat} -> (ni : Fin n) -> (v, w : Vect n ZZ) -> index ni (v<+>w) = (index ni v)<+>(index ni w)`
+	* `lemma_VectAddHead : (v, w : Vect (S n) ZZ) -> head(v<+>w) = (head v)<+>(head w)`
+	* `lemma_VectAddTail`
+	* `matrixAddEntrywise`, `matrixAddHead`, `matrixAddMapHead`, `matrixAddTail`, `matrixAddMapTail`
+
+Misc foundational
 
 ## FinOrdering
 
@@ -223,12 +249,13 @@ A library of properties to do w/ `Vect`s as a structure and functions to/from th
 * The theorem `weakenedInd` about comparing an index of a list to an index of its `init`.
 * The theorem `extensionalEqToMapEq` extending an extensional equality between functions to one between their `map`s over `Vect`s.
 * `composeUnderMap` w/c proves preservation of function composition for `Vect _`, what would be `functorComposition` in a `VerifiedFunctor` instance.
+* `updateDeleteAtChariz : deleteAt i $ updateAt i f xs = deleteAt i xs`
 
 * Compatibility between the operations of the ring (a) and of (Vect n a) as a module under (index).
 
-* `foldrImplRec` — The recursive equation for (foldr) over (Vect)s. Converts a right fold into a left fold.
+* `foldrImplRec` — The recursive equation for `foldr` over `Vect`s. Converts a right fold into a left fold.
 * `monoidrec : Monoid a => (v : a) -> (vs : Vect n a) -> sum' (v::vs) = v <+> sum' vs` — The recursive equation for sums in (Monoid)s over a (Vect _). Converts a right fold into a left fold.
-	* See `monoidrec1D`/...`2D` elsewhere.
+	* See `monoidrec1D`/...`2D` in Data.Matrix.LinearCombinations.
 
 ## Data.Matrix.Structural
 
@@ -239,9 +266,9 @@ A library of properties to do w/ `Matrix`s as a structure and functions to/from 
 * `transposeIndexChariz : {xs : Matrix n m a} -> index k $ transpose xs = getCol k xs`
 	* `transposeNHead: head $ transpose xs = map head xs`
 * `transposeNTail : transpose $ tail $ transpose xs = map tail xs`
-	* See also: `transposeNTail2` elsewhere
+	* See also: `transposeNTail2` in Data.Matrix.LinearCombinations
 
-* `vecMatMultIsTransposeVecMult`/`matVecIsVecTransposeMult` — The special cases of the transpose being an anti-endomorphism of matrix multiplication for vector-matrix and matrix-vector multiplication.
+* `vecMatMultIsTransposeVecMult`/`matVecIsVecTransposeMult` — The special cases of the transpose being an antiendomorphism of matrix multiplication for vector-matrix and matrix-vector multiplication.
 * `headVecMatMultChariz` — a vector-matrix product as mapped dot product lemma.
 
 * `matMultIndicesChariz : Ring a => {l : Matrix _ _ a} -> {r : Matrix _ _ a} -> indices i j (l<>r) = (index i l)<:>(getCol j r)` — the entrywise expression of a matrix product.

--- a/README.md
+++ b/README.md
@@ -13,26 +13,152 @@ These show what other kind of theorems are needed, but about the wrong objects t
 ## ZZGaussianElimination
 
 Contents:
-* Declaration of gaussian elimination as an algorithm which converts a matrix into one in row echelon form which spans it. `gaussElimlz : (xs : Matrix n m ZZ) -> (n' : Nat ** (gexs : Matrix n' m ZZ ** (rowEchelon gexs, bispanslz gexs xs)))`
+* Declaration of gaussian elimination as an algorithm which converts a matrix into one in row echelon form which spans it. `gaussElimlz : (xs : Matrix n m ZZ) -> (n' : Nat 	* (gexs : Matrix n' m ZZ 	* (rowEchelon gexs, bispanslz gexs xs)))`
 * Implementation of the second property, `rowEchelon`.
 * `leadingNonzeroCalc`, which takes a `Vect n ZZ` to its first index to a nonzero entry or a proof that all entries are zero.
 * `downAndNotRightOfEntryImpliesZ`, which says a matrix is zero below an index and at or to the left of a second index.
-* Implementation of column-zero elimination, `elimFirstCol : (xs : Matrix n (S predm) ZZ) -> Reader ZZGaussianElimination.gcdOfVectAlg (gexs : Matrix (S n) (S predm) ZZ ** (downAndNotRightOfEntryImpliesZ gexs FZ FZ, bispanslz gexs xs))`.
-* Implementation of the inductive step for elimination, `gaussElimlzIfGCD2 : (xs : Matrix n (S predm) ZZ) -> Reader ZZGaussianElimination.gcdOfVectAlg ( n' : Nat ** (gexs : Matrix n' (S predm) ZZ ** (rowEchelon gexs, bispanslz gexs xs)) )`
+* Implementation of column-zero elimination, `elimFirstCol : (xs : Matrix n (S predm) ZZ) -> Reader ZZGaussianElimination.gcdOfVectAlg (gexs : Matrix (S n) (S predm) ZZ 	* (downAndNotRightOfEntryImpliesZ gexs FZ FZ, bispanslz gexs xs))`.
+* Implementation of the inductive step for elimination, `gaussElimlzIfGCD2 : (xs : Matrix n (S predm) ZZ) -> Reader ZZGaussianElimination.gcdOfVectAlg ( n' : Nat 	* (gexs : Matrix n' (S predm) ZZ 	* (rowEchelon gexs, bispanslz gexs xs)) )`
 * `foldAutoind` - A vector fold over suppressed indices. Extends one witness for some predicate `p : (m : Nat) -> Fin (S m) -> a -> Type` to a `Vect` of them.
 * `foldAutoind2` - Same strength of result as `foldAutoind`, but applies where the predicate `p : (m : Nat) -> Fin (S m) -> (a m) -> Type` isn't naturally expressed or proved without affecting the type of the witnesses dealt with by this process.
 
 ## ZZModuleSpan
 
+__All proofs mentioned below are up to Issue #24 on GitHub being solved__
+
 Contents:
-* Definition of the *linearly spans* relation `spanslz` between two Vects of Vects of integers (where integers means inhabitants of Data.ZZ).
+
+* Definition of the *linearly spans* relation `spanslz` between two `Vect`s of `Vect`s of integers (where integers means inhabitants of Data.ZZ).
 	* Its maximal symmetric subrelation `bispanslz xs ys = (spanslz xs ys, spanslz ys xs)`.
-* Some definitions related to linear spans.
-* Proof of transitivity and reflexivity of `spanslz` using some unproved but known theorems.
-	* Their analogues for `bispanslz`, plus proof it's symmetric.
-* Sketches of proof of `zippyScale` associativity in terms of the equivalent matrix multiplication associativity. `zippyScale` is shorthand for a form of linear combination of the rows of a matrix over multiple vectors, as dealt with and proved extensionally equal to matrix multiplication in Data.Matrix.LinearCombinations.
-* Proof of `updateAtEquality : {ls : Matrix n k ZZ} -> {rs : Matrix k m ZZ} -> (updi : Fin n) -> (f : (i : Nat) -> Vect i ZZ -> Vect i ZZ) -> ( (la : Vect k ZZ) -> (f k la) <\> rs = f m $ la <\> rs ) -> zippyScale (updateAt updi (f k) ls) rs = updateAt updi (f m) (zippyScale ls rs)`, which lets you prove `vectMatLScalingCompatibility : {z : ZZ} -> {rs : Matrix k m ZZ} -> (z <#> la) <\> rs = z <#> (la <\> rs)` by a proof that works at least in the REPL, from which `spanRowScalelz : (z : ZZ) -> (updi : Fin n') -> spanslz xs ys -> spanslz xs (updateAt updi (z<#>) ys)` is proved.
-* Many propositions introduced. Towards the end of the file, after section "Proof of relational properties of span", the holes tend to be closer to known properties that will be used directly in the gaussian elimination algorithm, while towards the "Trivial lemmas and plumbing" section at the beginning of the file, the holes are generally strategies proposed for proving theorems about reordering vectors by a permutation, particularly the problem of reaching `spanslzAdditiveExchangeAt : (nel : Fin (S predn)) -> spanslz (updateAt nel (<+>(z<\>(deleteRow nel xs))) xs) xs` from `spanslzAdditiveExchange : spanslz ((y<+>(z<\>xs))::xs) (y::xs)`.
+* Def. `zippyScale`, shorthand for a form of linear combination of the rows of a matrix over multiple vectors, as proved extensionally equal to matrix multiplication by `timesMatMatAsMultipleLinearCombos` in Data.Matrix.LinearCombinations.
+* `spans` and `spansl`, which reflect that the original scope of the project was to cover Gaussian elimination (or a similar basis-normalization procedure) for more general ZZ-modules, but will be deleted.
+
+Proofs of relational properties of span:
+* Proof of transitivity and reflexivity of `spanslz`: `spanslzrefl`, `spanslzreflFromEq : (xs=ys) -> xs `spanslz` ys`, `spanslztrans`.
+	* Their analogues for `bispanslz`, plus proof `bispanslzsym` it's symmetric, and hence an equivalence relation.
+
+Proofs of algebraic properties of span — elementary row operations of row-addition and row-multiplication, and properties of adding a multiple of one row to another row in particular:
+* `spanScalelz : (z : ZZ) -> spanslz xs ys -> spanslz xs (z<#>ys)`
+* `spanAdd : spanslz xs ys -> spanslz xs zs -> spanslz xs (ys <+> zs)`
+	* `spanSub : spanslz xs ys -> spanslz xs zs -> spanslz xs (ys <-> zs)`
+* `spanslzAdditiveExchange : spanslz ((y<+>(z<\>xs))::xs) (y::xs)`
+	* `spanslzSubtractiveExchange : spanslz ((y<->(z<\>xs))::xs) (y::xs)`
+* `spanslzAdditivePreservation : spanslz (y::xs) ((y<+>(z<\>xs))::xs)`
+	* `spanslzSubtractivePreservation : spanslz (y::xs) ((y<->(z<\>xs))::xs)`
+* `spanRowScalelz : (z : ZZ) -> (updi : Fin n') -> spanslz xs ys -> spanslz xs (updateAt updi (z<#>) ys)`, which applies `updateAtEquality` to `vectMatLScalingCompatibility : {z : ZZ} -> {rs : Matrix k m ZZ} -> (z <#> la) <\> rs = z <#> (la <\> rs)`.
+* `bispanslzAdditiveExchangeAt : (nel : Fin (S predn)) -> bispanslz (updateAt nel (<+>(z<\>(deleteRow nel xs))) xs) xs`, which applies `headOpPreservesSpanslzImpliesUpdateAtDoes` and `headOpPreservesSpannedbylzImpliesUpdateAtDoes` to `spanslzAdditiveExchange` and `spanslzAdditivePreservation` respectively.
+	* `bispanslzSubtractiveExchangeAt : (nel : Fin (S predn)) -> bispanslz (updateAt nel (<->(z<\>(deleteRow nel xs))) xs) xs`
+
+Proofs of reordering/permutational properties — elementary row operation of row-switching:
+* ```permPreservesSpanslz : (sigma : Iso (Fin n) (Fin n))
+	-> {xs : Matrix n m ZZ}
+	-> spanslz (vectPermTo sigma xs) xs``` — A permutation of a `Vect` of `Vect`s does not change its span.
+* ```permPreservesSpannedbylz : (sigma : Iso (Fin n) (Fin n)) -> spanslz xs (vectPermTo sigma xs)``` — A permutation of a `Vect` of `Vect`s does not change its span.
+* ```concatSpanslzFlipConcat : {xs : Matrix n k ZZ} -> {ys : Matrix m k ZZ}
+	-> spanslz (xs++ys) (ys++xs)```
+* ```updateAtEquality : {ls : Matrix n k ZZ} -> {rs : Matrix k m ZZ} -> (updi : Fin n)
+	-> (f : (i : Nat) -> Vect i ZZ -> Vect i ZZ)
+	-> ( (la : Vect k ZZ) -> (f k la) <\> rs = f m $ la <\> rs )
+	-> zippyScale (updateAt updi (f k) ls) rs = updateAt updi (f m) (zippyScale ls rs)``` — reexpresses a product w/ an updated matrix as an update to the product w/ the un-updated matrix when a similar re-expression is valid for applying the updating function to an arbitrary vector under multiplication by the original non-updating matrix.
+* `headOpPreservesSpanslzImpliesUpdateAtDoes` — if an operation `f` can be applied to the head of any matrix and not change what it spans, it can be applied to any row of any matrix and not change what it spans.
+* `headOpPreservesSpannedbylzImpliesUpdateAtDoes` — if an operation `f` can be applied to the head of any matrix and not change what spans it, it can be applied to any row of any matrix and not change what spans it.
+
+Proofs of mixed properties, such as those to do w/ the underlying `Vect` (list) structure's meaning in terms of subspaces:
+* `spanslzNeutral : {xs : Matrix n w ZZ} -> spanslz xs Algebra.neutral` — every set of vectors spans the zero subspace (Zero matrix as terminal object P1)
+	* ```spanslzHeadCatNeutral : x::xs `spanslz` x::Algebra.neutral```
+	* `spanslzNullRowExtension : spanslz xs (Algebra.neutral::xs)`
+* `spannedlzByZeroId : {xs : Matrix n m ZZ} -> spanslz [] xs -> xs=neutral` — the span of the zero matrix is the zero subspace (Zero matrix as terminal object P2)
+	* ```spansImpliesSameFirstColNeutrality : xs `spanslz` ys -> getCol FZ xs = Algebra.neutral -> getCol FZ ys = Algebra.neutral```
+* `spanslzRowTimesSelf : spanslz xs [v<\>xs]` — row-vector multiples of matrix are, as a 1-vector `Vect`, spanned by the matrix as a `Vect` of `Vect`s. Put another way, the value of a linear map at a vector is in the span of the image of the basis under the linear map.
+	* ```spanslzHeadRow : (z : _) -> (zs : _) -> (z::zs) `spanslz` [z]```
+* `spanslzTail : {xs : Matrix n w ZZ} -> {ys : Matrix (S predn') w ZZ} -> spanslz xs ys -> spanslz xs (Data.Vect.tail ys)`
+* `extendSpanningLZsByPreconcatTrivially : spanslz xs ys -> spanslz (zs++xs) ys`
+	* `preserveSpanningLZByCons : spanslz xs ys -> spanslz (z::xs) ys`
+* `extendSpanningLZsByPostconcatTrivially : spanslz xs ys -> spanslz (xs++zs) ys`
+* `mergeSpannedLZs : spanslz xs ys -> spanslz xs zs -> spanslz xs (ys++zs)`
+* `concatSpansRellz : spanslz xs zs -> spanslz ys ws -> spanslz (xs++ys) (zs++ws)`
+* ```bispansSamevecExtension : xs `bispanslz` ys -> (v : Vect _ ZZ) -> (v::xs) `bispanslz` (v::ys)```
+* ```bispansNullcolExtension : (getCol FZ xs=Algebra.neutral)
+	-> ys `bispanslz` map Vect.tail xs
+	-> map ((Pos Z)::) ys `bispanslz` xs```
+
+Foundational - algebraic:
+* `zippyScaleIsAssociative`/`timesMatMatIsAssociative` — Proofs of `zippyScale` associativity and the equivalent matrix multiplication `(<>)` associativity.
+	* ```vecMatVecRebracketing : {l : Vect n ZZ}
+	-> {c : Matrix n m ZZ}
+	-> {r : Vect m ZZ}
+	-> l <:> (c</>r) = (l<\>c) <:> r``` — _RowVect_ \* (_Mat_ \* _Colvect_) = (_Rowvect_ \* _Mat_) \* _Colvect_; the two matrix actions involved in vector-matrix-vector multiplication are compatible.
+		* Informal proof using a custom notation for transcribing the relevant transformations and pieces of the matrix, and the interactions between them, when working w/ sums over matrix indices in the manner required to replicate the traditional proof w/out a general subsequencewise additive associativity law.
+* `dotBasisLIsIndex : (v : Vect d ZZ) -> basis i <:> v = index i v`/...`R`... — a vector's _i_th coordinate is the vector's dot product with the basis vector for the _i_th generator/axis.
+* `multIdLeftNeutral : (a : Matrix _ _ ZZ) -> Id <> a = a`/...`Right`... — the identity matrix's namesake.
+* `idMatSelfTranspose`
+* ```zipWithTimesIsDistributiveL : (l, c, r : Vect n ZZ)
+	-> zipWith (<.>) l $ c<+>r = zipWith (<.>) l c <+> zipWith (<.>) l r``` — pointwise vector multiplication is left-distributive over vector addition.
+* ```zipWithTimesIsRecDistributiveL : (l : Vect n ZZ)
+	-> (rs : Matrix m n ZZ)
+	-> zipWith (<.>) l $ monoidsum rs = monoidsum $ map (zipWith (<.>) l) rs``` — pointwise vector multiplication left-distibutes over a sum over a `Vect` of vectors.
+* `monoidsumNeutralIsNeutral1D`/...`2D` — The sum over the zero vector is zero, the sum over the zero matrix is the zero vector.
+* `sumTransposeMapRelation : (xs : Matrix n m ZZ) -> monoidsum $ transpose xs = map monoidsum xs` — view summing the transpose's row vectors together pointwise as replacing each of the original matrix's rows with their sum.
+* ```orderOfSummationExchange : (xs : Matrix n m ZZ)
+	-> monoidsum $ monoidsum xs = monoidsum $ monoidsum $ transpose xs``` — exchanging/interchanging the order of summation / of two iterated sums / of a double sum. Statement for iterated sums of the generalized associativity law (_x_ \+ _y_) \+ (_z_ \+ _w_)=(_x_ \+ _z_) \+ (_y_ \+ _w_).
+	* ```sumSumAsSumMapSum : (xs : Matrix n m ZZ)
+	-> monoidsum $ map monoidsum xs = monoidsum $ monoidsum xs``` — equivalent to the above.
+
+Foundational - permutations:
+* `vectPermTo : Iso (Fin n) (Fin n) -> Vect n a -> Vect n a`
+	* `vectPermToIndexChariz : index i $ vectPermTo sigma xs = index (runIso sigma i) xs`
+* `vectPermToRefl : vectPermTo Isomorphism.isoRefl xs = xs`
+* `vectPermToTrans : vectPermTo (isoTrans sigma tau) xs = vectPermTo sigma $ vectPermTo tau xs`
+* `vectPermToSym1 : vectPermTo (isoTrans sigma $ isoSym sigma) xs = xs`/`vectPermToSym2 : vectPermTo (isoTrans (isoSym sigma) sigma) xs = xs`
+* ```permMatrixId : (sigma : Iso (Fin n) (Fin n))
+	-> {xs : Matrix n m ZZ}
+	-> (vectPermTo sigma Id)<>xs = vectPermTo sigma xs``` — Permutation matrices perform permutations on matrices when multiplied with them.
+* ```permDoesntFixAValueNotFixed : (sigma : Iso (Fin n) (Fin n))
+	-> (nel1, nel2 : Fin n)
+	-> (runIso sigma nel1 = nel2)
+	-> Either (Not (runIso sigma nel2 = nel2)) (nel1 = nel2)```
+* ```permDoesntFix_corrolary : (sigma : Iso (Fin (S n)) (Fin (S n)))
+	-> (snel : Fin (S n))
+	-> Not (snel = FZ)
+	-> (runIso sigma snel = FZ)
+	-> Not (runIso sigma FZ = FZ)```
+* `weakenIsoByValFZ : Iso (Fin (S n)) (Fin (S n)) -> Iso (Fin n) (Fin n)`
+* ```rotateAt : (nel : Fin (S predn)) -> (sigma : Iso (Fin (S predn)) (Fin (S predn))
+		* (a : Type)
+		-> (xs : Vect (S predn) a)
+		-> vectPermTo sigma xs = index nel xs :: deleteAt nel xs)``` — The permutation w/c takes the first some elements of a `Vect` and cycles them to one position later.
+	* ex: ```> \xs => (getProof $ rotateAt $ 3 `shift` (FZ {k=5})) Char $ ['a','b','c']++xs```
+* Discusses a failed-to-implement system for permuting `xs++ys` to `ys++xs` (where `xs` is a `Vect _ a` for arbitrary `a`).
+* Considers `swapFZPerm`, the permutation which swaps the argument `Fin (S _)` w/ `FZ`, but finds the chosen implementation impossible.
+
+Foundational - fins:
+* `finReduce : (snel : Fin (S n)) -> Either (Fin n) (FZ = snel)`
+	* `finReduceIsLeft : (z = FS k) -> finReduce z = Left k`
+	* ```finReduceIsRight_sym : (z : Fin (S predn))
+	-> (prFZ : z = FZ)
+	-> (pr : FZ {k=predn} = z 	* Right pr = finReduce z)```
+* `splitFinFS : (i : Fin (S predn)) -> Either ( k : Fin predn 	* i = FS k ) ( i = Fin.FZ {k=predn} )`
+* ```splitFinAtConcat : (i : Fin $ n+m)
+	-> Either (k : Fin n 	* i = weakenN m k) (k : Fin m 	* i = shift n k)```
+* `indexConcatAsIndexAppendee : (i : Fin n) -> index (weakenN m i) $ xs++ys = index i xs`
+* `indexConcatAsIndexAppended : (i : Fin m) -> index (shift n i) $ xs++ys = index i ys`
+* `FSPreservesBoolEq : (i, j : Fin n) -> (FS i == FS j) = (i == j)`
+* `eqTrue_Fin : (i, j : Fin n) -> (i=j) -> (i==j)=True`
+* `notEqFalse_Fin : (i, j : Fin n) -> Not (i=j) -> (i==j)=False`
+
+Foundational - other:
+* `indexFinsIsIndex : index i $ fins n = i`/`indexRangeIsIndex : index i Vect.range = i`
+	* `rangeIsFins : Vect.range = Matrix.fins n`
+* `replaceAtIndexForm1 : (i=j) -> index i $ replaceAt j a v = a`/`replaceAtIndexForm2 : ((i=j)->Void) -> index i $ replaceAt j a v = index i v`
+* `idMatIndicesChariz : indices i j Id = kroneckerDelta i j`
+* `idMatIndexChariz : RingWithUnity a => index i $ Id {a=a} = basis i`
+	* `kroneckerDelta i j = ifThenElse (i==j) Algebra.unity Algebra.neutral`
+	* `kroneckerDeltaSym : RingWithUnity a => kroneckerDelta {a=a} i j = kroneckerDelta {a=a} j i`
+* ```runIso : Iso a b -> a -> b
+runIso (MkIso to _ _ _) = to```
+* `isoSymIsInvolution : isoSym $ isoSym sigma = sigma`
+* ```runIsoTrans : runIso (isoTrans sigma tau) x = runIso tau $ runIso sigma x```
+* `runIsoSym1 : runIso (isoTrans sigma $ isoSym sigma) x = x`/`runIsoSym2 : runIso (isoTrans (isoSym sigma) sigma) x = x`
 
 ## Data.Matrix.LinearCombinations
 
@@ -45,6 +171,7 @@ Most significant contents:
 Contents:
 * A(n) `LTRel` relation term meant for less-than relations, in an `OrdRel` class, and a `DecLT` class for decidable relations, where such an `OrdRel` whose `LTRel x y` is occupied will have a `decLT x y` giving an inhabitant and where unoccupied `decLT x y` will be a proof of this (some `LTRel x y -> Void`).
 * An instance of this for `Nat`, by which `Fin n` will be ordered indirectly through `finToNat`.
+* `lteToLTERel : {a, b : Nat} -> LTE a b -> LTERel a b`, relating `FinOrdering`'s version `LTERel` of the less-than-or-equal-to relation to `LTE`, from Prelude, for `Nat`s.
 
 ## Control.Algebra.ZZVerifiedInstances
 
@@ -58,5 +185,14 @@ Definitions:
 
 Ripped from comments of Classes.Verified, commenting out there coincides with definition of module being in the separate module Control.Algebra.VectorSpace from Control.Algebra.
 
-Declarations:
+Typeclass instances:
 * Verified module instance for `VerifiedRingWithUnity a => Matrix n m a`.
+* No such instance for `Vect`s, but proofs of the required properties.
+
+Trivial identities about (unital) rings:
+* `groupOpIsCancellativeL`/...`R` : Group operations are left/right cancellative.
+* Above ...`_Vect` : Analogues for `Vect`s.
+* `neutralSelfInverse`
+* `groupElemOwnDoubleImpliesNeut` : Groups have a unique idempotent, the identity.
+* `ringNeutralIsMultZeroL`/...`R` : Ring additive identity is a multiplicative zero.
+* `ringNegationCommutesWithLeftMult`/...`RightMult` : _a_ \* (\- _b_) = \- (_a_ \* _b_) = (\- _a_) \* _b_.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # verified-integer-gaussian-elimination
 
+Written in Idris 0.9.20
+
 Idris package looking to define, implement, and verify naiive Gaussian elimination over the integers in some system of linear algebra.
 
 Ignore these files:
@@ -9,6 +11,8 @@ Ignore these files:
 * IntegerOrdering.idr
 
 These show what other kind of theorems are needed, but about the wrong objects to be correct or to fit the system of linear algebra used in this package.
+
+__All proofs mentioned below are up to Issue #24 on GitHub being solved__
 
 ## ZZGaussianElimination
 
@@ -23,8 +27,6 @@ Contents:
 * `foldAutoind2` - Same strength of result as `foldAutoind`, but applies where the predicate `p : (m : Nat) -> Fin (S m) -> (a m) -> Type` isn't naturally expressed or proved without affecting the type of the witnesses dealt with by this process.
 
 ## ZZModuleSpan
-
-__All proofs mentioned below are up to Issue #24 on GitHub being solved__
 
 Contents:
 
@@ -175,7 +177,7 @@ Contents:
 
 ## Control.Algebra.ZZVerifiedInstances
 
-Contents: Declaration for `instance VerifiedRingWithUnity ZZ`
+Contents: Typeclass instance `instance VerifiedRingWithUnity ZZ`
 
 ## Data.Matrix.AlgebraicVerified
 
@@ -196,3 +198,15 @@ Trivial identities about (unital) rings:
 * `groupElemOwnDoubleImpliesNeut` : Groups have a unique idempotent, the identity.
 * `ringNeutralIsMultZeroL`/...`R` : Ring additive identity is a multiplicative zero.
 * `ringNegationCommutesWithLeftMult`/...`RightMult` : _a_ \* (\- _b_) = \- (_a_ \* _b_) = (\- _a_) \* _b_.
+
+## Data.Matrix.ZZVerified
+
+Identities whose proof is particular to ZZ, mainly because of the limitations caused by Issue #24 on GitHub. Some duplicate functionality.
+
+Proved:
+* `zzVecNeutralIsVecPtwiseProdZeroL`/...`R` — the zero vector is a zero of the dot product `(<:>)`. Name is incorrect for the identity stated. Overlaps w/ `neutralVectIsDotProductZero_R`/...`L` respectively in Data.Matrix.LinearCombinations.
+* `zzVecNeutralIsVecMatMultZero`/...`MatVec`... — likewise of vector-matrix and matrix-vector multiplication. Overlaps w/ `neutralVectIsVectTimesZero`/`emptyVectIsTimesVectZero` in Data.Matrix.LinearCombinations respectively.
+
+Declared:
+* `zzVecNeutralIsNeutralL`/...`R` — the zero vector is an identity for vector addition. Overlaps w/ `monoidNeutralIsNeutralL_Vect` in Data.Matrix.AlgebraicVerified.
+* `zzVecScalarUnityIsUnity` — scalar multiplication of a `Vect _ ZZ` by `1` yields the original vector. Overlaps w/ `moduleScalarUnityIsUnity_Vect` in Data.Matrix.AlgebraicVerified.

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -1848,7 +1848,7 @@ vecMatVecRebracketing {l} {c} {r} {n} {m} =
 				)
 				$ sym indexMapChariz
 
--- but probably (VerifiedCommutativeRing a)
+-- Generalizes to (VerifiedCommutativeRing a)
 timesMatMatIsAssociative : {l : Matrix _ _ ZZ} -> {c : Matrix _ _ ZZ} -> {r : Matrix _ _ ZZ}
 	-> l <> (c <> r) = (l <> c) <> r
 timesMatMatIsAssociative = vecIndexwiseEq
@@ -1980,34 +1980,6 @@ zippyScaleIdLeftNeutral _ = trans (sym $ timesMatMatAsMultipleLinearCombos _ _) 
 -- Note this typechecks when (multIdLeftNeutral) has the class-generic type signature.
 zippyScaleIdRightNeutral : (a : Matrix _ _ ZZ) -> a `zippyScale` Id = a
 zippyScaleIdRightNeutral _ = trans (sym $ timesMatMatAsMultipleLinearCombos _ _) $ multIdRightNeutral _
-
-{-
-
-Implementations explored:
-
-------------------
-
-zippyScaleIsAssociative {l} {c} {r} = trans (cong {f=zippyScale l} $ sym $ timesMatMatAsMultipleLinearCombos c r) $ trans (sym $ timesMatMatAsMultipleLinearCombos l (c<>r)) $ trans (timesMatMatIsAssociative {l=l} {c=c} {r=r}) $ trans (cong {f=(<> r)} $ timesMatMatAsMultipleLinearCombos l c) $ timesMatMatAsMultipleLinearCombos (l `zippyScale` c) r
-
-------
-
-zippyScaleIsAssociative {l} {c} {r} = trans (cong {f=zippyScale l} $ sym $ timesMatMatAsMultipleLinearCombos c r) $ trans (sym $ timesMatMatAsMultipleLinearCombos l (c<>r)) $ trans (timesMatMatIsAssociative {l=l} {c=c} {r=r}) $ trans (timesMatMatAsMultipleLinearCombos (l <> c) r) $ cong {f=(flip zippyScale) r} $ timesMatMatAsMultipleLinearCombos l c
-
-------
-
-zippyScaleIsAssociative {l} {c} {r} = trans
-		( rewrite sym (timesMatMatAsMultipleLinearCombos l (c `zippyScale` r)) in rewrite sym (timesMatMatAsMultipleLinearCombos c r) in timesMatMatIsAssociative {l=l} {c=c} {r=r}
-		)
-		( rewrite sym (timesMatMatAsMultipleLinearCombos l c) in rewrite sym (timesMatMatAsMultipleLinearCombos (l <> c) r) in timesMatMatIsAssociative {l=l} {c=c} {r=r}
-		)
-
-zippyScaleIsAssociative2 : {l : Matrix _ _ ZZ} -> {c : Matrix _ _ ZZ} -> {r : Matrix _ _ ZZ} -> map (\rs => monoidsum $ zipWith (<#>) rs (map (\rs => monoidsum $ zipWith (<#>) rs r) c)) l = map (\rs => monoidsum $ zipWith (<#>) rs r) (map (\rs => monoidsum $ zipWith (<#>) rs c) l)
-zippyScaleIsAssociative2 {l} {c} {r} = trans
-		( rewrite sym (timesMatMatAsMultipleLinearCombos l (c `zippyScale` r)) in rewrite sym (timesMatMatAsMultipleLinearCombos c r) in timesMatMatIsAssociative {l=l} {c=c} {r=r}
-		)
-		( rewrite sym (timesMatMatAsMultipleLinearCombos l c) in rewrite sym (timesMatMatAsMultipleLinearCombos (l <> c) r) in timesMatMatIsAssociative {l=l} {c=c} {r=r}
-		)
--}
 
 
 


### PR DESCRIPTION
Update docs from the last 3 months for all changes to modules since the `zzgauss-lemmas` revert, and covering all previously undocumented modules.
