### PR TITLE
Instance resolution problem work

### DIFF
--- a/Control/Algebra/DiamondInstances.idr
+++ b/Control/Algebra/DiamondInstances.idr
@@ -1,0 +1,60 @@
+module Control.Algebra.DiamondInstances
+
+import Control.Algebra
+import Classes.Verified -- definition of verified algebras other than modules
+
+
+
+{-
+Diamond instances
+explicitly referenced for using in treating diamond inheritance problems
+* VerifiedGroup a -> Semigroup a
+* VerifiedRingWithUnity a -> Semigroup a
+* VerifiedRingWithUnity a -> Ring a
+-}
+
+
+
+vgrpVerifiedMonoid : VerifiedGroup a -> VerifiedMonoid a
+vgrpVerifiedMonoid a = %instance
+
+vgrpGroup : VerifiedGroup a -> Group a
+vgrpGroup a = %instance
+
+vmonSemigrp : VerifiedMonoid a -> Semigroup a
+vmonSemigrp a = %instance
+
+grpSemigrp : Group a -> Semigroup a
+grpSemigrp a = %instance
+
+vgrpSemigroupByVMon : VerifiedGroup a -> Semigroup a
+vgrpSemigroupByVMon = vmonSemigrp . vgrpVerifiedMonoid
+
+vgrpSemigroupByGrp : VerifiedGroup a -> Semigroup a
+vgrpSemigroupByGrp = grpSemigrp . vgrpGroup
+
+vrwuSemigroupByVMon : VerifiedRingWithUnity a -> Semigroup a
+vrwuSemigroupByVMon a = vgrpSemigroupByVMon %instance
+
+vrwuSemigroupByGrp : VerifiedRingWithUnity a -> Semigroup a
+vrwuSemigroupByGrp a = vgrpSemigroupByGrp %instance
+
+
+
+vrwuVerifiedRing : VerifiedRingWithUnity a -> VerifiedRing a
+vrwuVerifiedRing a = %instance
+
+vrwuRingWithUnity : VerifiedRingWithUnity a -> RingWithUnity a
+vrwuRingWithUnity a = %instance
+
+vrRing : VerifiedRing a -> Ring a
+vrRing a = %instance
+
+rwuRing : RingWithUnity a -> Ring a
+rwuRing a = %instance
+
+vrwuRingByVR : VerifiedRingWithUnity a -> Ring a
+vrwuRingByVR = vrRing . vrwuVerifiedRing
+
+vrwuRingByRWU : VerifiedRingWithUnity a -> Ring a
+vrwuRingByRWU = rwuRing . vrwuRingWithUnity

--- a/Data/Matrix/AlgebraicVerified.idr
+++ b/Data/Matrix/AlgebraicVerified.idr
@@ -72,6 +72,19 @@ moduleScalarMultiplyComposition_Vect : (VerifiedRingWithUnity a) => ( x, y : a )
 moduleScalarMultiplyComposition_Vect x y [] = Refl
 moduleScalarMultiplyComposition_Vect x y (v::vs) ?= vecHeadtailsEq (ringOpIsAssociative x y v) $ moduleScalarMultiplyComposition_Vect x y vs
 
+moduleScalarMultiplyComposition_Vect2 : (VerifiedRingWithUnity a)
+	=> {auto ok :
+		((<.>) @{vrwuRingByRWU $ the (VerifiedRingWithUnity a) %instance})
+		= ((<.>) @{vrwuRingByVR $ the (VerifiedRingWithUnity a) %instance})
+		}
+	-> ( x, y : a ) -> ( v : Vect n a )
+	-> x <#> (y <#> v) = x <.> y <#> v
+moduleScalarMultiplyComposition_Vect2 x y [] = Refl
+moduleScalarMultiplyComposition_Vect2 {ok} x y (v::vs) =
+	vecHeadtailsEq
+		(rewrite ok in ringOpIsAssociative x y v)
+	$ moduleScalarMultiplyComposition_Vect2 x y vs
+
 {-
 This doesn't exist because of a diamond inheritance problem.
 -}
@@ -189,6 +202,16 @@ abelianGroupOpIsCommutative_Mat (l::ls) (r::rs) = vecHeadtailsEq (abelianGroupOp
 moduleScalarMultiplyComposition_Mat : (VerifiedRingWithUnity a) => ( x, y : a ) -> ( v : Matrix n m a ) -> x <#> (y <#> v) = x <.> y <#> v
 moduleScalarMultiplyComposition_Mat x y [] = Refl
 moduleScalarMultiplyComposition_Mat x y (v::vs) = vecHeadtailsEq (moduleScalarMultiplyComposition_Vect _ _ _) $ moduleScalarMultiplyComposition_Mat _ _ _
+
+moduleScalarMultiplyComposition_Mat2 : (VerifiedRingWithUnity a)
+	=> {auto ok :
+		((<.>) @{vrwuRingByRWU $ the (VerifiedRingWithUnity a) %instance})
+		= ((<.>) @{vrwuRingByVR $ the (VerifiedRingWithUnity a) %instance})
+		}
+	-> ( x, y : a ) -> ( v : Matrix n m a )
+	-> x <#> (y <#> v) = x <.> y <#> v
+moduleScalarMultiplyComposition_Mat2 x y [] = Refl
+moduleScalarMultiplyComposition_Mat2 x y (v::vs) = vecHeadtailsEq (moduleScalarMultiplyComposition_Vect2 _ _ _) $ moduleScalarMultiplyComposition_Mat2 _ _ _
 
 moduleScalarUnityIsUnity_Mat : (VerifiedRingWithUnity a) => ( v : Matrix n m a ) -> (Algebra.unity {a=a}) <#> v = v
 moduleScalarUnityIsUnity_Mat [] = Refl

--- a/Data/Matrix/AlgebraicVerified.idr
+++ b/Data/Matrix/AlgebraicVerified.idr
@@ -104,9 +104,35 @@ moduleScalarMultDistributiveWRTVectorAddition_Vect : (VerifiedRingWithUnity a) =
 moduleScalarMultDistributiveWRTVectorAddition_Vect s [] [] = Refl
 moduleScalarMultDistributiveWRTVectorAddition_Vect s (v::vs) (w::ws) ?= vecHeadtailsEq (ringOpIsDistributiveL s v w) $ moduleScalarMultDistributiveWRTVectorAddition_Vect s vs ws
 
+moduleScalarMultDistributiveWRTVectorAddition_Vect2 : (VerifiedRingWithUnity a)
+	=> {auto ok :
+		((<.>) @{vrwuRingByRWU $ the (VerifiedRingWithUnity a) %instance})
+		= ((<.>) @{vrwuRingByVR $ the (VerifiedRingWithUnity a) %instance})
+		}
+	-> (s : a) -> (v, w : Vect n a)
+	-> s <#> v <+> w = (s <#> v) <+> (s <#> w)
+moduleScalarMultDistributiveWRTVectorAddition_Vect2 s [] [] = Refl
+moduleScalarMultDistributiveWRTVectorAddition_Vect2 {ok} s (v::vs) (w::ws) =
+	vecHeadtailsEq
+		(rewrite ok in ringOpIsDistributiveL s v w)
+	$ moduleScalarMultDistributiveWRTVectorAddition_Vect2 s vs ws
+
 moduleScalarMultDistributiveWRTModuleAddition_Vect : (VerifiedRingWithUnity a) => (s, t : a) -> (v : Vect n a) -> s <+> t <#> v = (s <#> v) <+> (t <#> v)
 moduleScalarMultDistributiveWRTModuleAddition_Vect s t [] = Refl
 moduleScalarMultDistributiveWRTModuleAddition_Vect s t (v::vs) ?= vecHeadtailsEq (ringOpIsDistributiveR s t v) $ moduleScalarMultDistributiveWRTModuleAddition_Vect s t vs
+
+moduleScalarMultDistributiveWRTModuleAddition_Vect2 : (VerifiedRingWithUnity a)
+	=> {auto ok :
+		((<.>) @{vrwuRingByRWU $ the (VerifiedRingWithUnity a) %instance})
+		= ((<.>) @{vrwuRingByVR $ the (VerifiedRingWithUnity a) %instance})
+		}
+	-> (s, t : a) -> (v : Vect n a)
+	-> s <+> t <#> v = (s <#> v) <+> (t <#> v)
+moduleScalarMultDistributiveWRTModuleAddition_Vect2 s t [] = Refl
+moduleScalarMultDistributiveWRTModuleAddition_Vect2 {ok} s t (v::vs) =
+	vecHeadtailsEq
+		(rewrite ok in ringOpIsDistributiveR s t v)
+	$ moduleScalarMultDistributiveWRTModuleAddition_Vect2 s t vs
 
 {-
 instance (VerifiedRingWithUnity a) => VerifiedSemigroup (Vect n a) where
@@ -185,9 +211,29 @@ moduleScalarMultDistributiveWRTVectorAddition_Mat : (VerifiedRingWithUnity a) =>
 moduleScalarMultDistributiveWRTVectorAddition_Mat s [] [] = Refl
 moduleScalarMultDistributiveWRTVectorAddition_Mat s (v::vs) (w::ws) = vecHeadtailsEq (moduleScalarMultDistributiveWRTVectorAddition_Vect _ _ _) $ moduleScalarMultDistributiveWRTVectorAddition_Mat _ _ _
 
+moduleScalarMultDistributiveWRTVectorAddition_Mat2 : (VerifiedRingWithUnity a)
+	=> {auto ok :
+		((<.>) @{vrwuRingByRWU $ the (VerifiedRingWithUnity a) %instance})
+		= ((<.>) @{vrwuRingByVR $ the (VerifiedRingWithUnity a) %instance})
+		}
+	-> (s : a) -> (v, w : Matrix n m a)
+	-> s <#> v <+> w = (s <#> v) <+> (s <#> w)
+moduleScalarMultDistributiveWRTVectorAddition_Mat2 s [] [] = Refl
+moduleScalarMultDistributiveWRTVectorAddition_Mat2 s (v::vs) (w::ws) = vecHeadtailsEq (moduleScalarMultDistributiveWRTVectorAddition_Vect2 _ _ _) $ moduleScalarMultDistributiveWRTVectorAddition_Mat2 _ _ _
+
 moduleScalarMultDistributiveWRTModuleAddition_Mat : (VerifiedRingWithUnity a) => (s, t : a) -> (v : Matrix n m a) -> s <+> t <#> v = (s <#> v) <+> (t <#> v)
 moduleScalarMultDistributiveWRTModuleAddition_Mat s t [] = Refl
 moduleScalarMultDistributiveWRTModuleAddition_Mat s t (v::vs) = vecHeadtailsEq (moduleScalarMultDistributiveWRTModuleAddition_Vect _ _ _) $ moduleScalarMultDistributiveWRTModuleAddition_Mat _ _ _
+
+moduleScalarMultDistributiveWRTModuleAddition_Mat2 : (VerifiedRingWithUnity a)
+	=> {auto ok :
+		((<.>) @{vrwuRingByRWU $ the (VerifiedRingWithUnity a) %instance})
+		= ((<.>) @{vrwuRingByVR $ the (VerifiedRingWithUnity a) %instance})
+		}
+	-> (s, t : a) -> (v : Matrix n m a)
+	-> s <+> t <#> v = (s <#> v) <+> (t <#> v)
+moduleScalarMultDistributiveWRTModuleAddition_Mat2 s t [] = Refl
+moduleScalarMultDistributiveWRTModuleAddition_Mat2 s t (v::vs) = vecHeadtailsEq (moduleScalarMultDistributiveWRTModuleAddition_Vect2 _ _ _) $ moduleScalarMultDistributiveWRTModuleAddition_Mat2 _ _ _
 
 
 instance (VerifiedRingWithUnity a) => VerifiedSemigroup (Matrix n m a) where

--- a/Data/Matrix/AlgebraicVerified.idr
+++ b/Data/Matrix/AlgebraicVerified.idr
@@ -68,18 +68,18 @@ abelianGroupOpIsCommutative_Vect : (VerifiedRingWithUnity a) => (l, r : Vect n a
 abelianGroupOpIsCommutative_Vect [] [] = Refl
 abelianGroupOpIsCommutative_Vect (l::ls) (r::rs) = vecHeadtailsEq (abelianGroupOpIsCommutative _ _) $ abelianGroupOpIsCommutative_Vect _ _
 
-moduleScalarMultiplyComposition_Vect2 : (VerifiedRingWithUnity a)
+moduleScalarMultiplyComposition_Vect : (VerifiedRingWithUnity a)
 	=> {auto ok :
 		((<.>) @{vrwuRingByRWU $ the (VerifiedRingWithUnity a) %instance})
 		= ((<.>) @{vrwuRingByVR $ the (VerifiedRingWithUnity a) %instance})
 		}
 	-> ( x, y : a ) -> ( v : Vect n a )
 	-> x <#> (y <#> v) = x <.> y <#> v
-moduleScalarMultiplyComposition_Vect2 x y [] = Refl
-moduleScalarMultiplyComposition_Vect2 {ok} x y (v::vs) =
+moduleScalarMultiplyComposition_Vect x y [] = Refl
+moduleScalarMultiplyComposition_Vect {ok} x y (v::vs) =
 	vecHeadtailsEq
 		(rewrite ok in ringOpIsAssociative x y v)
-	$ moduleScalarMultiplyComposition_Vect2 x y vs
+	$ moduleScalarMultiplyComposition_Vect x y vs
 
 {-
 This doesn't exist because of a diamond inheritance problem.
@@ -95,45 +95,45 @@ where the equality between (<.>)s coming from different instances is
 an automatically solved assumption.
 -}
 
-moduleScalarUnityIsUnity_Vect2 : (VerifiedRingWithUnity a)
+moduleScalarUnityIsUnity_Vect : (VerifiedRingWithUnity a)
 	=> {auto ok :
 		((<.>) @{vrwuRingByRWU $ the (VerifiedRingWithUnity a) %instance})
 		= ((<.>) @{vrwuRingByVR $ the (VerifiedRingWithUnity a) %instance})
 		}
 	-> ( v : Vect n a )
 	-> (Algebra.unity {a=a}) <#> v = v
-moduleScalarUnityIsUnity_Vect2 [] = Refl
-moduleScalarUnityIsUnity_Vect2 {ok} (v::vs) =
+moduleScalarUnityIsUnity_Vect [] = Refl
+moduleScalarUnityIsUnity_Vect {ok} (v::vs) =
 	vecHeadtailsEq (
 		trans (cong {f=\t => t Algebra.unity v} ok)
 		$ ringWithUnityIsUnityR v)
-	$ moduleScalarUnityIsUnity_Vect2 vs
+	$ moduleScalarUnityIsUnity_Vect vs
 
-moduleScalarMultDistributiveWRTVectorAddition_Vect2 : (VerifiedRingWithUnity a)
+moduleScalarMultDistributiveWRTVectorAddition_Vect : (VerifiedRingWithUnity a)
 	=> {auto ok :
 		((<.>) @{vrwuRingByRWU $ the (VerifiedRingWithUnity a) %instance})
 		= ((<.>) @{vrwuRingByVR $ the (VerifiedRingWithUnity a) %instance})
 		}
 	-> (s : a) -> (v, w : Vect n a)
 	-> s <#> v <+> w = (s <#> v) <+> (s <#> w)
-moduleScalarMultDistributiveWRTVectorAddition_Vect2 s [] [] = Refl
-moduleScalarMultDistributiveWRTVectorAddition_Vect2 {ok} s (v::vs) (w::ws) =
+moduleScalarMultDistributiveWRTVectorAddition_Vect s [] [] = Refl
+moduleScalarMultDistributiveWRTVectorAddition_Vect {ok} s (v::vs) (w::ws) =
 	vecHeadtailsEq
 		(rewrite ok in ringOpIsDistributiveL s v w)
-	$ moduleScalarMultDistributiveWRTVectorAddition_Vect2 s vs ws
+	$ moduleScalarMultDistributiveWRTVectorAddition_Vect s vs ws
 
-moduleScalarMultDistributiveWRTModuleAddition_Vect2 : (VerifiedRingWithUnity a)
+moduleScalarMultDistributiveWRTModuleAddition_Vect : (VerifiedRingWithUnity a)
 	=> {auto ok :
 		((<.>) @{vrwuRingByRWU $ the (VerifiedRingWithUnity a) %instance})
 		= ((<.>) @{vrwuRingByVR $ the (VerifiedRingWithUnity a) %instance})
 		}
 	-> (s, t : a) -> (v : Vect n a)
 	-> s <+> t <#> v = (s <#> v) <+> (t <#> v)
-moduleScalarMultDistributiveWRTModuleAddition_Vect2 s t [] = Refl
-moduleScalarMultDistributiveWRTModuleAddition_Vect2 {ok} s t (v::vs) =
+moduleScalarMultDistributiveWRTModuleAddition_Vect s t [] = Refl
+moduleScalarMultDistributiveWRTModuleAddition_Vect {ok} s t (v::vs) =
 	vecHeadtailsEq
 		(rewrite ok in ringOpIsDistributiveR s t v)
-	$ moduleScalarMultDistributiveWRTModuleAddition_Vect2 s t vs
+	$ moduleScalarMultDistributiveWRTModuleAddition_Vect s t vs
 
 {-
 instance (VerifiedRingWithUnity a) => VerifiedSemigroup (Vect n a) where
@@ -187,46 +187,46 @@ abelianGroupOpIsCommutative_Mat : (VerifiedRingWithUnity a) => (l, r : Matrix n 
 abelianGroupOpIsCommutative_Mat [] [] = Refl
 abelianGroupOpIsCommutative_Mat (l::ls) (r::rs) = vecHeadtailsEq (abelianGroupOpIsCommutative_Vect _ _) $ abelianGroupOpIsCommutative_Mat _ _
 
-moduleScalarMultiplyComposition_Mat2 : (VerifiedRingWithUnity a)
+moduleScalarMultiplyComposition_Mat : (VerifiedRingWithUnity a)
 	=> {auto ok :
 		((<.>) @{vrwuRingByRWU $ the (VerifiedRingWithUnity a) %instance})
 		= ((<.>) @{vrwuRingByVR $ the (VerifiedRingWithUnity a) %instance})
 		}
 	-> ( x, y : a ) -> ( v : Matrix n m a )
 	-> x <#> (y <#> v) = x <.> y <#> v
-moduleScalarMultiplyComposition_Mat2 x y [] = Refl
-moduleScalarMultiplyComposition_Mat2 x y (v::vs) = vecHeadtailsEq (moduleScalarMultiplyComposition_Vect2 _ _ _) $ moduleScalarMultiplyComposition_Mat2 _ _ _
+moduleScalarMultiplyComposition_Mat x y [] = Refl
+moduleScalarMultiplyComposition_Mat x y (v::vs) = vecHeadtailsEq (moduleScalarMultiplyComposition_Vect _ _ _) $ moduleScalarMultiplyComposition_Mat _ _ _
 
-moduleScalarUnityIsUnity_Mat2 : (VerifiedRingWithUnity a)
+moduleScalarUnityIsUnity_Mat : (VerifiedRingWithUnity a)
 	=> {auto ok :
 		((<.>) @{vrwuRingByRWU $ the (VerifiedRingWithUnity a) %instance})
 		= ((<.>) @{vrwuRingByVR $ the (VerifiedRingWithUnity a) %instance})
 		}
 	-> ( v : Matrix n m a )
 	-> (Algebra.unity {a=a}) <#> v = v
-moduleScalarUnityIsUnity_Mat2 [] = Refl
-moduleScalarUnityIsUnity_Mat2 (v::vs) = vecHeadtailsEq (moduleScalarUnityIsUnity_Vect2 _)
-	$ moduleScalarUnityIsUnity_Mat2 _
+moduleScalarUnityIsUnity_Mat [] = Refl
+moduleScalarUnityIsUnity_Mat (v::vs) = vecHeadtailsEq (moduleScalarUnityIsUnity_Vect _)
+	$ moduleScalarUnityIsUnity_Mat _
 
-moduleScalarMultDistributiveWRTVectorAddition_Mat2 : (VerifiedRingWithUnity a)
+moduleScalarMultDistributiveWRTVectorAddition_Mat : (VerifiedRingWithUnity a)
 	=> {auto ok :
 		((<.>) @{vrwuRingByRWU $ the (VerifiedRingWithUnity a) %instance})
 		= ((<.>) @{vrwuRingByVR $ the (VerifiedRingWithUnity a) %instance})
 		}
 	-> (s : a) -> (v, w : Matrix n m a)
 	-> s <#> v <+> w = (s <#> v) <+> (s <#> w)
-moduleScalarMultDistributiveWRTVectorAddition_Mat2 s [] [] = Refl
-moduleScalarMultDistributiveWRTVectorAddition_Mat2 s (v::vs) (w::ws) = vecHeadtailsEq (moduleScalarMultDistributiveWRTVectorAddition_Vect2 _ _ _) $ moduleScalarMultDistributiveWRTVectorAddition_Mat2 _ _ _
+moduleScalarMultDistributiveWRTVectorAddition_Mat s [] [] = Refl
+moduleScalarMultDistributiveWRTVectorAddition_Mat s (v::vs) (w::ws) = vecHeadtailsEq (moduleScalarMultDistributiveWRTVectorAddition_Vect _ _ _) $ moduleScalarMultDistributiveWRTVectorAddition_Mat _ _ _
 
-moduleScalarMultDistributiveWRTModuleAddition_Mat2 : (VerifiedRingWithUnity a)
+moduleScalarMultDistributiveWRTModuleAddition_Mat : (VerifiedRingWithUnity a)
 	=> {auto ok :
 		((<.>) @{vrwuRingByRWU $ the (VerifiedRingWithUnity a) %instance})
 		= ((<.>) @{vrwuRingByVR $ the (VerifiedRingWithUnity a) %instance})
 		}
 	-> (s, t : a) -> (v : Matrix n m a)
 	-> s <+> t <#> v = (s <#> v) <+> (t <#> v)
-moduleScalarMultDistributiveWRTModuleAddition_Mat2 s t [] = Refl
-moduleScalarMultDistributiveWRTModuleAddition_Mat2 s t (v::vs) = vecHeadtailsEq (moduleScalarMultDistributiveWRTModuleAddition_Vect2 _ _ _) $ moduleScalarMultDistributiveWRTModuleAddition_Mat2 _ _ _
+moduleScalarMultDistributiveWRTModuleAddition_Mat s t [] = Refl
+moduleScalarMultDistributiveWRTModuleAddition_Mat s t (v::vs) = vecHeadtailsEq (moduleScalarMultDistributiveWRTModuleAddition_Vect _ _ _) $ moduleScalarMultDistributiveWRTModuleAddition_Mat _ _ _
 
 
 instance (VerifiedRingWithUnity a) => VerifiedSemigroup (Matrix n m a) where

--- a/Data/Matrix/AlgebraicVerified.idr
+++ b/Data/Matrix/AlgebraicVerified.idr
@@ -3,38 +3,11 @@ module Data.Matrix.AlgebraicVerified
 import Control.Algebra
 import Control.Algebra.VectorSpace -- definition of module
 import Classes.Verified -- definition of verified algebras other than modules
+import Control.Algebra.DiamondInstances
 import Data.Matrix
 import Data.Matrix.Algebraic -- module instances; from Idris 0.9.20
 
 import Data.Vect.Structural
-
-
-
-{-
-Diamond instances
-explicitly referenced for using in treating diamond inheritance problems
-* VerifiedRingWithUnity a -> Ring a
--}
-
-
-
-vrwuVerifiedRing : VerifiedRingWithUnity a -> VerifiedRing a
-vrwuVerifiedRing a = %instance
-
-vrwuRingWithUnity : VerifiedRingWithUnity a -> RingWithUnity a
-vrwuRingWithUnity a = %instance
-
-vrRing : VerifiedRing a -> Ring a
-vrRing a = %instance
-
-rwuRing : RingWithUnity a -> Ring a
-rwuRing a = %instance
-
-vrwuRingByVR : VerifiedRingWithUnity a -> Ring a
-vrwuRingByVR = vrRing . vrwuVerifiedRing
-
-vrwuRingByRWU : VerifiedRingWithUnity a -> Ring a
-vrwuRingByRWU = rwuRing . vrwuRingWithUnity
 
 
 

--- a/Data/Matrix/AlgebraicVerified.idr
+++ b/Data/Matrix/AlgebraicVerified.idr
@@ -68,10 +68,6 @@ abelianGroupOpIsCommutative_Vect : (VerifiedRingWithUnity a) => (l, r : Vect n a
 abelianGroupOpIsCommutative_Vect [] [] = Refl
 abelianGroupOpIsCommutative_Vect (l::ls) (r::rs) = vecHeadtailsEq (abelianGroupOpIsCommutative _ _) $ abelianGroupOpIsCommutative_Vect _ _
 
-moduleScalarMultiplyComposition_Vect : (VerifiedRingWithUnity a) => ( x, y : a ) -> ( v : Vect n a ) -> x <#> (y <#> v) = x <.> y <#> v
-moduleScalarMultiplyComposition_Vect x y [] = Refl
-moduleScalarMultiplyComposition_Vect x y (v::vs) ?= vecHeadtailsEq (ringOpIsAssociative x y v) $ moduleScalarMultiplyComposition_Vect x y vs
-
 moduleScalarMultiplyComposition_Vect2 : (VerifiedRingWithUnity a)
 	=> {auto ok :
 		((<.>) @{vrwuRingByRWU $ the (VerifiedRingWithUnity a) %instance})
@@ -87,13 +83,13 @@ moduleScalarMultiplyComposition_Vect2 {ok} x y (v::vs) =
 
 {-
 This doesn't exist because of a diamond inheritance problem.
--}
 
 moduleScalarUnityIsUnity_Vect : (VerifiedRingWithUnity a) => ( v : Vect n a ) -> (Algebra.unity {a=a}) <#> v = v
 moduleScalarUnityIsUnity_Vect [] = Refl
 moduleScalarUnityIsUnity_Vect (v::vs) = ?moduleScalarUnityIsUnity_Vect'
 
-{-
+---
+
 So we use this instead,
 where the equality between (<.>)s coming from different instances is
 an automatically solved assumption.
@@ -113,10 +109,6 @@ moduleScalarUnityIsUnity_Vect2 {ok} (v::vs) =
 		$ ringWithUnityIsUnityR v)
 	$ moduleScalarUnityIsUnity_Vect2 vs
 
-moduleScalarMultDistributiveWRTVectorAddition_Vect : (VerifiedRingWithUnity a) => (s : a) -> (v, w : Vect n a) -> s <#> v <+> w = (s <#> v) <+> (s <#> w)
-moduleScalarMultDistributiveWRTVectorAddition_Vect s [] [] = Refl
-moduleScalarMultDistributiveWRTVectorAddition_Vect s (v::vs) (w::ws) ?= vecHeadtailsEq (ringOpIsDistributiveL s v w) $ moduleScalarMultDistributiveWRTVectorAddition_Vect s vs ws
-
 moduleScalarMultDistributiveWRTVectorAddition_Vect2 : (VerifiedRingWithUnity a)
 	=> {auto ok :
 		((<.>) @{vrwuRingByRWU $ the (VerifiedRingWithUnity a) %instance})
@@ -129,10 +121,6 @@ moduleScalarMultDistributiveWRTVectorAddition_Vect2 {ok} s (v::vs) (w::ws) =
 	vecHeadtailsEq
 		(rewrite ok in ringOpIsDistributiveL s v w)
 	$ moduleScalarMultDistributiveWRTVectorAddition_Vect2 s vs ws
-
-moduleScalarMultDistributiveWRTModuleAddition_Vect : (VerifiedRingWithUnity a) => (s, t : a) -> (v : Vect n a) -> s <+> t <#> v = (s <#> v) <+> (t <#> v)
-moduleScalarMultDistributiveWRTModuleAddition_Vect s t [] = Refl
-moduleScalarMultDistributiveWRTModuleAddition_Vect s t (v::vs) ?= vecHeadtailsEq (ringOpIsDistributiveR s t v) $ moduleScalarMultDistributiveWRTModuleAddition_Vect s t vs
 
 moduleScalarMultDistributiveWRTModuleAddition_Vect2 : (VerifiedRingWithUnity a)
 	=> {auto ok :
@@ -199,10 +187,6 @@ abelianGroupOpIsCommutative_Mat : (VerifiedRingWithUnity a) => (l, r : Matrix n 
 abelianGroupOpIsCommutative_Mat [] [] = Refl
 abelianGroupOpIsCommutative_Mat (l::ls) (r::rs) = vecHeadtailsEq (abelianGroupOpIsCommutative_Vect _ _) $ abelianGroupOpIsCommutative_Mat _ _
 
-moduleScalarMultiplyComposition_Mat : (VerifiedRingWithUnity a) => ( x, y : a ) -> ( v : Matrix n m a ) -> x <#> (y <#> v) = x <.> y <#> v
-moduleScalarMultiplyComposition_Mat x y [] = Refl
-moduleScalarMultiplyComposition_Mat x y (v::vs) = vecHeadtailsEq (moduleScalarMultiplyComposition_Vect _ _ _) $ moduleScalarMultiplyComposition_Mat _ _ _
-
 moduleScalarMultiplyComposition_Mat2 : (VerifiedRingWithUnity a)
 	=> {auto ok :
 		((<.>) @{vrwuRingByRWU $ the (VerifiedRingWithUnity a) %instance})
@@ -212,12 +196,6 @@ moduleScalarMultiplyComposition_Mat2 : (VerifiedRingWithUnity a)
 	-> x <#> (y <#> v) = x <.> y <#> v
 moduleScalarMultiplyComposition_Mat2 x y [] = Refl
 moduleScalarMultiplyComposition_Mat2 x y (v::vs) = vecHeadtailsEq (moduleScalarMultiplyComposition_Vect2 _ _ _) $ moduleScalarMultiplyComposition_Mat2 _ _ _
-
-moduleScalarUnityIsUnity_Mat : (VerifiedRingWithUnity a) => ( v : Matrix n m a ) -> (Algebra.unity {a=a}) <#> v = v
-moduleScalarUnityIsUnity_Mat [] = Refl
-moduleScalarUnityIsUnity_Mat (v::vs) = vecHeadtailsEq (moduleScalarUnityIsUnity_Vect _) $ moduleScalarUnityIsUnity_Mat _
-
-{- Solves same diamond inheritance problem as in (moduleScalarUnityIsUnity_Vect2) -}
 
 moduleScalarUnityIsUnity_Mat2 : (VerifiedRingWithUnity a)
 	=> {auto ok :
@@ -230,10 +208,6 @@ moduleScalarUnityIsUnity_Mat2 [] = Refl
 moduleScalarUnityIsUnity_Mat2 (v::vs) = vecHeadtailsEq (moduleScalarUnityIsUnity_Vect2 _)
 	$ moduleScalarUnityIsUnity_Mat2 _
 
-moduleScalarMultDistributiveWRTVectorAddition_Mat : (VerifiedRingWithUnity a) => (s : a) -> (v, w : Matrix n m a) -> s <#> v <+> w = (s <#> v) <+> (s <#> w)
-moduleScalarMultDistributiveWRTVectorAddition_Mat s [] [] = Refl
-moduleScalarMultDistributiveWRTVectorAddition_Mat s (v::vs) (w::ws) = vecHeadtailsEq (moduleScalarMultDistributiveWRTVectorAddition_Vect _ _ _) $ moduleScalarMultDistributiveWRTVectorAddition_Mat _ _ _
-
 moduleScalarMultDistributiveWRTVectorAddition_Mat2 : (VerifiedRingWithUnity a)
 	=> {auto ok :
 		((<.>) @{vrwuRingByRWU $ the (VerifiedRingWithUnity a) %instance})
@@ -243,10 +217,6 @@ moduleScalarMultDistributiveWRTVectorAddition_Mat2 : (VerifiedRingWithUnity a)
 	-> s <#> v <+> w = (s <#> v) <+> (s <#> w)
 moduleScalarMultDistributiveWRTVectorAddition_Mat2 s [] [] = Refl
 moduleScalarMultDistributiveWRTVectorAddition_Mat2 s (v::vs) (w::ws) = vecHeadtailsEq (moduleScalarMultDistributiveWRTVectorAddition_Vect2 _ _ _) $ moduleScalarMultDistributiveWRTVectorAddition_Mat2 _ _ _
-
-moduleScalarMultDistributiveWRTModuleAddition_Mat : (VerifiedRingWithUnity a) => (s, t : a) -> (v : Matrix n m a) -> s <+> t <#> v = (s <#> v) <+> (t <#> v)
-moduleScalarMultDistributiveWRTModuleAddition_Mat s t [] = Refl
-moduleScalarMultDistributiveWRTModuleAddition_Mat s t (v::vs) = vecHeadtailsEq (moduleScalarMultDistributiveWRTModuleAddition_Vect _ _ _) $ moduleScalarMultDistributiveWRTModuleAddition_Mat _ _ _
 
 moduleScalarMultDistributiveWRTModuleAddition_Mat2 : (VerifiedRingWithUnity a)
 	=> {auto ok :
@@ -274,13 +244,6 @@ instance (VerifiedRingWithUnity a) => VerifiedGroup (Matrix n m a) where {
 
 instance (VerifiedRingWithUnity a) => VerifiedAbelianGroup (Matrix n m a) where {
 	abelianGroupOpIsCommutative = abelianGroupOpIsCommutative_Mat
-}
-
-instance (VerifiedRingWithUnity a) => VerifiedModule a (Matrix n m a) where {
-	moduleScalarMultiplyComposition = moduleScalarMultiplyComposition_Mat
-	moduleScalarUnityIsUnity = moduleScalarUnityIsUnity_Mat
-	moduleScalarMultDistributiveWRTVectorAddition = moduleScalarMultDistributiveWRTVectorAddition_Mat
-	moduleScalarMultDistributiveWRTModuleAddition = moduleScalarMultDistributiveWRTModuleAddition_Mat
 }
 
 

--- a/Data/Matrix/LinearCombinations.idr
+++ b/Data/Matrix/LinearCombinations.idr
@@ -934,7 +934,7 @@ negScalarToScaledNegVect_zz : (s : ZZ)
 negScalarToScaledNegVect_zz s x =
 	trans (cong {f=(<#>x)}
 		$ trans (negativeIsNegOneTimesRight s) $ ringOpIsCommutative_ZZ _ s)
-	$ trans (sym $ moduleScalarMultiplyComposition_Vect s _ x)
+	$ trans (sym $ moduleScalarMultiplyComposition_Vect2 s _ x)
 	$ cong {f=(s<#>)} $ vectTimesNegOneIsNeg_zz x
 
 negScalarToScaledNegMat_zz : (s : ZZ)
@@ -943,5 +943,5 @@ negScalarToScaledNegMat_zz : (s : ZZ)
 negScalarToScaledNegMat_zz s x =
 	trans (cong {f=(<#>x)}
 		$ trans (negativeIsNegOneTimesRight s) $ ringOpIsCommutative_ZZ _ s)
-	$ trans (sym $ moduleScalarMultiplyComposition_Mat s _ x)
+	$ trans (sym $ moduleScalarMultiplyComposition_Mat2 s _ x)
 	$ cong {f=(s<#>)} $ matTimesNegOneIsNeg_zz x

--- a/Data/Matrix/LinearCombinations.idr
+++ b/Data/Matrix/LinearCombinations.idr
@@ -883,7 +883,7 @@ vectTimesNegOneIsNeg_zz : (xs : Vect n ZZ)
 	-> (Algebra.inverse $ the ZZ $ Algebra.unity) <#> xs = Algebra.inverse xs
 vectTimesNegOneIsNeg_zz xs = groupOpIsCancellativeR_Vect _ _ xs
 	$ trans (cong {f=(((Algebra.inverse $ Algebra.unity {a=ZZ}) <#> xs)<+>)}
-		$ sym $ moduleScalarUnityIsUnity_Vect xs)
+		$ sym $ moduleScalarUnityIsUnity_Vect2 {ok=Refl} xs)
 	$ trans (sym $ moduleScalarMultDistributiveWRTModuleAddition_Vect
 		(Algebra.inverse $ Algebra.unity {a=ZZ}) (Algebra.unity {a=ZZ}) xs)
 	$ trans (cong {f=(<#>xs)} $ groupInverseIsInverseR $ Algebra.unity {a=ZZ})
@@ -894,7 +894,7 @@ matTimesNegOneIsNeg_zz : (xs : Matrix n m ZZ)
 	-> (Algebra.inverse $ the ZZ $ Algebra.unity) <#> xs = Algebra.inverse xs
 matTimesNegOneIsNeg_zz xs = groupOpIsCancellativeR _ _ xs
 	$ trans (cong {f=(((Algebra.inverse $ Algebra.unity {a=ZZ}) <#> xs)<+>)}
-		$ sym $ moduleScalarUnityIsUnity {a=ZZ} xs)
+		$ sym $ moduleScalarUnityIsUnity_Mat2 {ok=Refl} {a=ZZ} xs)
 	$ trans (sym $ moduleScalarMultDistributiveWRTModuleAddition
 		(Algebra.inverse $ Algebra.unity {a=ZZ}) (Algebra.unity {a=ZZ}) xs)
 	$ trans (cong {f=(<#>xs)} $ groupInverseIsInverseR $ Algebra.unity {a=ZZ})

--- a/Data/Matrix/LinearCombinations.idr
+++ b/Data/Matrix/LinearCombinations.idr
@@ -3,6 +3,7 @@ module Data.Matrix.LinearCombinations
 import Control.Algebra
 import Control.Algebra.VectorSpace -- definition of module
 import Classes.Verified -- definition of verified algebras other than modules
+import Control.Algebra.DiamondInstances
 import Data.Matrix
 import Data.Matrix.Algebraic -- module instances; from Idris 0.9.20
 

--- a/Data/Matrix/LinearCombinations.idr
+++ b/Data/Matrix/LinearCombinations.idr
@@ -884,8 +884,8 @@ vectTimesNegOneIsNeg_zz : (xs : Vect n ZZ)
 	-> (Algebra.inverse $ the ZZ $ Algebra.unity) <#> xs = Algebra.inverse xs
 vectTimesNegOneIsNeg_zz xs = groupOpIsCancellativeR_Vect _ _ xs
 	$ trans (cong {f=(((Algebra.inverse $ Algebra.unity {a=ZZ}) <#> xs)<+>)}
-		$ sym $ moduleScalarUnityIsUnity_Vect2 {ok=Refl} xs)
-	$ trans (sym $ moduleScalarMultDistributiveWRTModuleAddition_Vect2 {ok=Refl}
+		$ sym $ moduleScalarUnityIsUnity_Vect {ok=Refl} xs)
+	$ trans (sym $ moduleScalarMultDistributiveWRTModuleAddition_Vect {ok=Refl}
 		(Algebra.inverse $ Algebra.unity {a=ZZ}) (Algebra.unity {a=ZZ}) xs)
 	$ trans (cong {f=(<#>xs)} $ groupInverseIsInverseR $ Algebra.unity {a=ZZ})
 	$ trans (neutralScalarIsScalarMultNeutral_zzVect xs)
@@ -895,8 +895,8 @@ matTimesNegOneIsNeg_zz : (xs : Matrix n m ZZ)
 	-> (Algebra.inverse $ the ZZ $ Algebra.unity) <#> xs = Algebra.inverse xs
 matTimesNegOneIsNeg_zz xs = groupOpIsCancellativeR _ _ xs
 	$ trans (cong {f=(((Algebra.inverse $ Algebra.unity {a=ZZ}) <#> xs)<+>)}
-		$ sym $ moduleScalarUnityIsUnity_Mat2 {a=ZZ} xs)
-	$ trans (sym $ moduleScalarMultDistributiveWRTModuleAddition_Mat2
+		$ sym $ moduleScalarUnityIsUnity_Mat {a=ZZ} xs)
+	$ trans (sym $ moduleScalarMultDistributiveWRTModuleAddition_Mat
 		(Algebra.inverse $ Algebra.unity {a=ZZ}) (Algebra.unity {a=ZZ}) xs)
 	$ trans (cong {f=(<#>xs)} $ groupInverseIsInverseR $ Algebra.unity {a=ZZ})
 	$ trans (neutralScalarIsScalarMultNeutral_zzMat xs)
@@ -934,7 +934,7 @@ negScalarToScaledNegVect_zz : (s : ZZ)
 negScalarToScaledNegVect_zz s x =
 	trans (cong {f=(<#>x)}
 		$ trans (negativeIsNegOneTimesRight s) $ ringOpIsCommutative_ZZ _ s)
-	$ trans (sym $ moduleScalarMultiplyComposition_Vect2 s _ x)
+	$ trans (sym $ moduleScalarMultiplyComposition_Vect s _ x)
 	$ cong {f=(s<#>)} $ vectTimesNegOneIsNeg_zz x
 
 negScalarToScaledNegMat_zz : (s : ZZ)
@@ -943,5 +943,5 @@ negScalarToScaledNegMat_zz : (s : ZZ)
 negScalarToScaledNegMat_zz s x =
 	trans (cong {f=(<#>x)}
 		$ trans (negativeIsNegOneTimesRight s) $ ringOpIsCommutative_ZZ _ s)
-	$ trans (sym $ moduleScalarMultiplyComposition_Mat2 s _ x)
+	$ trans (sym $ moduleScalarMultiplyComposition_Mat s _ x)
 	$ cong {f=(s<#>)} $ matTimesNegOneIsNeg_zz x

--- a/Data/Matrix/LinearCombinations.idr
+++ b/Data/Matrix/LinearCombinations.idr
@@ -885,7 +885,7 @@ vectTimesNegOneIsNeg_zz : (xs : Vect n ZZ)
 vectTimesNegOneIsNeg_zz xs = groupOpIsCancellativeR_Vect _ _ xs
 	$ trans (cong {f=(((Algebra.inverse $ Algebra.unity {a=ZZ}) <#> xs)<+>)}
 		$ sym $ moduleScalarUnityIsUnity_Vect2 {ok=Refl} xs)
-	$ trans (sym $ moduleScalarMultDistributiveWRTModuleAddition_Vect
+	$ trans (sym $ moduleScalarMultDistributiveWRTModuleAddition_Vect2 {ok=Refl}
 		(Algebra.inverse $ Algebra.unity {a=ZZ}) (Algebra.unity {a=ZZ}) xs)
 	$ trans (cong {f=(<#>xs)} $ groupInverseIsInverseR $ Algebra.unity {a=ZZ})
 	$ trans (neutralScalarIsScalarMultNeutral_zzVect xs)
@@ -895,8 +895,8 @@ matTimesNegOneIsNeg_zz : (xs : Matrix n m ZZ)
 	-> (Algebra.inverse $ the ZZ $ Algebra.unity) <#> xs = Algebra.inverse xs
 matTimesNegOneIsNeg_zz xs = groupOpIsCancellativeR _ _ xs
 	$ trans (cong {f=(((Algebra.inverse $ Algebra.unity {a=ZZ}) <#> xs)<+>)}
-		$ sym $ moduleScalarUnityIsUnity_Mat2 {ok=Refl} {a=ZZ} xs)
-	$ trans (sym $ moduleScalarMultDistributiveWRTModuleAddition
+		$ sym $ moduleScalarUnityIsUnity_Mat2 {a=ZZ} xs)
+	$ trans (sym $ moduleScalarMultDistributiveWRTModuleAddition_Mat2
 		(Algebra.inverse $ Algebra.unity {a=ZZ}) (Algebra.unity {a=ZZ}) xs)
 	$ trans (cong {f=(<#>xs)} $ groupInverseIsInverseR $ Algebra.unity {a=ZZ})
 	$ trans (neutralScalarIsScalarMultNeutral_zzMat xs)

--- a/Data/Matrix/ZZVerified.idr
+++ b/Data/Matrix/ZZVerified.idr
@@ -93,10 +93,10 @@ zzVecNeutralIsMatVecMultZero : (xs : Matrix n m ZZ) -> xs </> Algebra.neutral = 
 zzVecNeutralIsMatVecMultZero xs = trans (matVecMultIsVecTransposeMult Algebra.neutral xs) $ zzVecNeutralIsVecMatMultZero (transpose xs)
 
 zzVecNeutralIsNeutralL : (l : Vect n ZZ) -> l<+>Algebra.neutral=l
--- zzVecNeutralIsNeutralL = monoidNeutralIsNeutralL
+zzVecNeutralIsNeutralL = monoidNeutralIsNeutralL_Vect
 
 zzVecNeutralIsNeutralR : (r : Vect n ZZ) -> Algebra.neutral<+>r=r
--- zzVecNeutralIsNeutralR = monoidNeutralIsNeutralR
+zzVecNeutralIsNeutralR = monoidNeutralIsNeutralR_Vect
 
 zzVecScalarUnityIsUnity : (v : Vect n ZZ) -> (Algebra.unity {a=ZZ}) <#> v = v
 zzVecScalarUnityIsUnity = moduleScalarUnityIsUnity_Vect2

--- a/Data/Matrix/ZZVerified.idr
+++ b/Data/Matrix/ZZVerified.idr
@@ -78,7 +78,12 @@ ZZVerified.zzVecNeutralIsVecPtwiseProdZeroL' = proof
 
 zzVecNeutralIsVecPtwiseProdZeroR : (xs : Vect n ZZ) -> Algebra.neutral <:> xs = Algebra.neutral
 zzVecNeutralIsVecPtwiseProdZeroR [] = Refl
--- zzVecNeutralIsVecPtwiseProdZeroR (x::xs) = vecHeadtailsEq (ringNeutralIsMultZeroL x) $ zzVecNeutralIsVecPtwiseProdZeroR xs
+zzVecNeutralIsVecPtwiseProdZeroR (x::xs) =
+	trans ( foldrImplRec (<+>) (Pos 0) id
+		(Algebra.neutral <.> x)
+		(zipWith (<.>) Algebra.neutral xs) )
+	$ trans ( rewrite ringNeutralIsMultZeroL x in monoidNeutralIsNeutralR _ )
+	$ zzVecNeutralIsVecPtwiseProdZeroR xs
 
 zzVecNeutralIsVecMatMultZero : (xs : Matrix n m ZZ) -> Algebra.neutral <\> xs = Algebra.neutral
 zzVecNeutralIsVecMatMultZero xs {m=Z} = zeroVecEq

--- a/Data/Matrix/ZZVerified.idr
+++ b/Data/Matrix/ZZVerified.idr
@@ -100,4 +100,4 @@ zzVecNeutralIsNeutralR : (r : Vect n ZZ) -> Algebra.neutral<+>r=r
 zzVecNeutralIsNeutralR = monoidNeutralIsNeutralR_Vect
 
 zzVecScalarUnityIsUnity : (v : Vect n ZZ) -> (Algebra.unity {a=ZZ}) <#> v = v
-zzVecScalarUnityIsUnity = moduleScalarUnityIsUnity_Vect2
+zzVecScalarUnityIsUnity = moduleScalarUnityIsUnity_Vect

--- a/Data/Matrix/ZZVerified.idr
+++ b/Data/Matrix/ZZVerified.idr
@@ -45,10 +45,36 @@ ringVecNeutralIsVecMatMultZero : VerifiedRing a => (xs : Matrix n m a) -> Algebr
 ringVecNeutralIsVecMatMultZero xs = trans (vecMatMultTransposeEq Algebra.neutral xs) $ ringVecNeutralIsMatVecMultZero $ transpose xs
 -}
 
-zzVecNeutralIsVecPtwiseProdZeroL : (xs : Vect n ZZ) -> xs <:> Algebra.neutral = Algebra.neutral
+zzVecNeutralIsVecPtwiseProdZeroL :
+	(xs : Vect n ZZ)
+	-> xs <:> Algebra.neutral = Algebra.neutral
 zzVecNeutralIsVecPtwiseProdZeroL [] = Refl
-zzVecNeutralIsVecPtwiseProdZeroL (x::xs) = ?zzVecNeutralIsVecPtwiseProdZeroL'
--- zzVecNeutralIsVecPtwiseProdZeroL (x::xs) = vecHeadtailsEq (ringNeutralIsMultZeroR x) $ zzVecNeutralIsVecPtwiseProdZeroL xs
+zzVecNeutralIsVecPtwiseProdZeroL (x::xs) =
+	trans ( foldrImplRec (<+>) (Pos 0) id
+		(x <.> Algebra.neutral)
+		(zipWith (<.>) xs Algebra.neutral) )
+	$ trans ( rewrite ringNeutralIsMultZeroR x in monoidNeutralIsNeutralR _ )
+	$ zzVecNeutralIsVecPtwiseProdZeroL xs
+{-
+Couldn't do this:
+
+> zzVecNeutralIsVecPtwiseProdZeroL (x::xs) = vecHeadtailsEq (ringNeutralIsMultZeroR x) $ zzVecNeutralIsVecPtwiseProdZeroL xs
+
+Discovered this proof by ordered inspection following this proof script:
+
+ZZVerified.zzVecNeutralIsVecPtwiseProdZeroL' = proof
+  intros
+  let pr' = zzVecNeutralIsVecPtwiseProdZeroL xs
+  exact _ pr'
+  compute
+  intro computedPr
+  exact trans _ computedPr
+  -- The script thusfar makes it possible to identify the missing theorem.
+  exact trans ( foldrImplRec (<+>) (Pos 0) id (x <.> Algebra.neutral) (zipWith (<.>) xs Algebra.neutral) ) $ _
+  compute
+  rewrite sym $ ringNeutralIsMultZeroR x
+  exact monoidNeutralIsNeutralR _
+-}
 
 zzVecNeutralIsVecPtwiseProdZeroR : (xs : Vect n ZZ) -> Algebra.neutral <:> xs = Algebra.neutral
 zzVecNeutralIsVecPtwiseProdZeroR [] = Refl

--- a/Data/Matrix/ZZVerified.idr
+++ b/Data/Matrix/ZZVerified.idr
@@ -47,6 +47,7 @@ ringVecNeutralIsVecMatMultZero xs = trans (vecMatMultTransposeEq Algebra.neutral
 
 zzVecNeutralIsVecPtwiseProdZeroL : (xs : Vect n ZZ) -> xs <:> Algebra.neutral = Algebra.neutral
 zzVecNeutralIsVecPtwiseProdZeroL [] = Refl
+zzVecNeutralIsVecPtwiseProdZeroL (x::xs) = ?zzVecNeutralIsVecPtwiseProdZeroL'
 -- zzVecNeutralIsVecPtwiseProdZeroL (x::xs) = vecHeadtailsEq (ringNeutralIsMultZeroR x) $ zzVecNeutralIsVecPtwiseProdZeroL xs
 
 zzVecNeutralIsVecPtwiseProdZeroR : (xs : Vect n ZZ) -> Algebra.neutral <:> xs = Algebra.neutral
@@ -67,4 +68,4 @@ zzVecNeutralIsNeutralR : (r : Vect n ZZ) -> Algebra.neutral<+>r=r
 -- zzVecNeutralIsNeutralR = monoidNeutralIsNeutralR
 
 zzVecScalarUnityIsUnity : (v : Vect n ZZ) -> (Algebra.unity {a=ZZ}) <#> v = v
--- zzVecScalarUnityIsUnity = moduleScalarUnityIsUnity
+zzVecScalarUnityIsUnity = moduleScalarUnityIsUnity_Vect2

--- a/Data/Matrix/ZZVerified.idr
+++ b/Data/Matrix/ZZVerified.idr
@@ -3,6 +3,7 @@ module Data.Matrix.ZZVerified
 import Control.Algebra
 import Control.Algebra.VectorSpace -- definition of module
 import Classes.Verified -- definition of verified algebras other than modules
+import Control.Algebra.DiamondInstances
 import Data.Matrix
 import Data.Matrix.Algebraic -- module instances; from Idris 0.9.20
 import Data.Matrix.AlgebraicVerified

--- a/Data/Vect/Structural.idr
+++ b/Data/Vect/Structural.idr
@@ -4,43 +4,9 @@ module Data.Vect.Structural
 import Control.Algebra
 import Control.Algebra.VectorSpace -- definition of module
 import Classes.Verified -- definition of verified algebras other than modules
+import Control.Algebra.DiamondInstances
 import Data.Matrix
 import Data.Matrix.Algebraic -- module instances; from Idris 0.9.20
-
-
-
-{-
-Diamond instances
-explicitly referenced for using in treating diamond inheritance problems
-* VerifiedGroup a -> Semigroup a
-* VerifiedRingWithUnity a -> Semigroup a
--}
-
-
-
-vgrpVerifiedMonoid : VerifiedGroup a -> VerifiedMonoid a
-vgrpVerifiedMonoid a = %instance
-
-vgrpGroup : VerifiedGroup a -> Group a
-vgrpGroup a = %instance
-
-vmonSemigrp : VerifiedMonoid a -> Semigroup a
-vmonSemigrp a = %instance
-
-grpSemigrp : Group a -> Semigroup a
-grpSemigrp a = %instance
-
-vgrpSemigroupByVMon : VerifiedGroup a -> Semigroup a
-vgrpSemigroupByVMon = vmonSemigrp . vgrpVerifiedMonoid
-
-vgrpSemigroupByGrp : VerifiedGroup a -> Semigroup a
-vgrpSemigroupByGrp = grpSemigrp . vgrpGroup
-
-vrwuSemigroupByVMon : VerifiedRingWithUnity a -> Semigroup a
-vrwuSemigroupByVMon a = vgrpSemigroupByVMon %instance
-
-vrwuSemigroupByGrp : VerifiedRingWithUnity a -> Semigroup a
-vrwuSemigroupByGrp a = vgrpSemigroupByGrp %instance
 
 
 
@@ -290,9 +256,15 @@ indexCompatSub {ok} xs ys i = rewrite ok in
 	$ cong {f=((index i xs)<+>)}
 	$ indexCompatInverse ys i
 
-indexCompatScaling : VerifiedRingWithUnity a => (r : a) -> (xs : Vect n a) -> (i : Fin n) -> index i $ r <#> xs = r <.> index i xs
+indexCompatScaling : VerifiedRingWithUnity a
+	=> {auto ok :
+		((<.>) @{vrwuRingByRWU $ the (VerifiedRingWithUnity a) %instance})
+		= ((<.>) @{vrwuRingByVR $ the (VerifiedRingWithUnity a) %instance})
+		}
+	-> (r : a) -> (xs : Vect n a) -> (i : Fin n)
+	-> index i $ r <#> xs = r <.> index i xs
 indexCompatScaling r [] i = FinZElim i
-indexCompatScaling r (x::xs) FZ = ?indexCompatScaling_lemma_1 -- Should be Refl
+indexCompatScaling r (x::xs) FZ {ok} = cong {f=\t => t r x} ok
 indexCompatScaling r (x::xs) (FS preli) = indexCompatScaling r xs preli
 
 

--- a/ZZGaussianEliminationLemmas.idr
+++ b/ZZGaussianEliminationLemmas.idr
@@ -2,6 +2,7 @@ module ZZGaussianEliminationLemmas
 
 import Control.Algebra
 import Classes.Verified
+import Control.Algebra.DiamondInstances
 import Control.Algebra.VectorSpace -- definition of module
 
 import Data.Matrix

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -3,6 +3,7 @@ module ZZModuleSpan
 import Control.Algebra
 import Control.Algebra.VectorSpace -- definition of module
 import Classes.Verified -- definition of verified algebras other than modules
+import Control.Algebra.DiamondInstances
 import Data.Matrix
 import Data.Matrix.Algebraic -- module instances; from Idris 0.9.20
 import Data.Matrix.AlgebraicVerified

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -2213,7 +2213,7 @@ spanSub' = proof
   let spanAdd' = spanAdd {xs=xs} {ys=ys} {zs = inverse zs}
   refine spanAdd'
   exact prxy
-  exact spanslztrans (spanScalelz (inverse unity) prxz) $ replace {P=\t => spanslz ((<#>) (inverse $ unity {a=ZZ}) zs) t} (trans ( negScalarToScaledNegMat_zz (unity {a=ZZ}) zs ) ( moduleScalarUnityIsUnity {a=ZZ} (inverse zs) )) spanslzrefl
+  exact spanslztrans (spanScalelz (inverse unity) prxz) $ replace {P=\t => spanslz ((<#>) (inverse $ unity {a=ZZ}) zs) t} (trans ( negScalarToScaledNegMat_zz (unity {a=ZZ}) zs ) ( moduleScalarUnityIsUnity_Mat2 {a=ZZ} (inverse zs) )) spanslzrefl
 
 {-
 -- Works in REPL only

--- a/ZZModuleSpan.idr
+++ b/ZZModuleSpan.idr
@@ -2214,7 +2214,7 @@ spanSub' = proof
   let spanAdd' = spanAdd {xs=xs} {ys=ys} {zs = inverse zs}
   refine spanAdd'
   exact prxy
-  exact spanslztrans (spanScalelz (inverse unity) prxz) $ replace {P=\t => spanslz ((<#>) (inverse $ unity {a=ZZ}) zs) t} (trans ( negScalarToScaledNegMat_zz (unity {a=ZZ}) zs ) ( moduleScalarUnityIsUnity_Mat2 {a=ZZ} (inverse zs) )) spanslzrefl
+  exact spanslztrans (spanScalelz (inverse unity) prxz) $ replace {P=\t => spanslz ((<#>) (inverse $ unity {a=ZZ}) zs) t} (trans ( negScalarToScaledNegMat_zz (unity {a=ZZ}) zs ) ( moduleScalarUnityIsUnity_Mat {a=ZZ} (inverse zs) )) spanslzrefl
 
 {-
 -- Works in REPL only


### PR DESCRIPTION
Material related to diamond inheritance problems solves them in a way which preserves the proofs' applicability to general (VerifiedRingWithUnity)s, but the instance of (VerifiedModule) for matrices must itself be discarded because there are missing equalities between methods of the different (Ring) instances inferred from a (VerifiedRingWithUnity) instance:

* Removed: instance (VerifiedRingWithUnity a) => VerifiedModule a (Matrix n m a)
* Added: Control.Algebra.DiamondInstances

The instance could be satisfied by a (VerifiedRingWithUnity) class that carries the proofs of equality between operations across different instances, as taken in the arguments to the changed definitions listed below.

Definitions changed include:
* indexCompatSub
* indexCompatScaling
* moduleScalarUnityIsUnity_Vect
* moduleScalarUnityIsUnity_Mat
* moduleScalarMultDistributiveWRTVectorAddition_Vect
* moduleScalarMultDistributiveWRTModuleAddition_Vect
* moduleScalarMultDistributiveWRTVectorAddition_Mat
* moduleScalarMultDistributiveWRTModuleAddition_Mat
* moduleScalarMultiplyComposition_Vect
* moduleScalarMultiplyComposition_Mat

No relevant holes left (none are dependencies for the current algorithm or proof).
Besides verified GCD, this completes the program.
Solves Issue #24.
