### PR TITLE
Connect bezout's identity to gaussian elimination

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ Mostly complete:
 	* Idris confirms it's total.
 * We also have (bezoutsIdentityZZIfModulo), a verified GCD algorithm producer.
 	* Idris does not confirm it's total - this uses the euclidean algorithm, for which proof of termination is nontrivial, & out of Idris's depth.
-* We're missing:
-	* A verified modulo operator
-	* A verified GCD -> "GCD of vector" algorithm.
-* Which fit the verified things together:
-	* (gaussElimlzIfGCD) takes a "GCD of vector" algorithm as an argument, and produced a verified gaussian elimination algorithm.
+* We're missing a verified modulo operator.
+* These then fit together:
+	* (gaussElimlzIfGCD) takes a GCD algorithm as an argument, and produces a gaussian elimination algorithm.
 	* (bezoutsIdentityZZIfModulo) takes a modulo operator as an argument, and produces a GCD algorithm.
+	* In particular,
+	`\mfn => \mpr => gaussElimlzIfGCD {m=5} {n=3} $ bezoutsIdentityZZIfModulo mfn mpr`
+	typechecks.
 * ... to form a verified gaussian elimination algorithm.
 
 ## ZZGaussianElimination
@@ -26,8 +27,8 @@ Main elimination algorithms.
 Index:
 * Template & usage for do notation pattern matching technique
 * elimFirstCol
-* gaussElimlzIfGCD3
-* gaussElimlzIfGCD2
+* gaussElimlzIfVectGCD2
+* gaussElimlzIfVectGCD
 * gaussElimlzIfGCD
 * Appendix Elim.General.Meta
 
@@ -35,6 +36,7 @@ Satellite modules:
 * ZZGaussianEliminationLemmas
 * ZZGaussianEliminationNoMonad
   Implementation of (elimFirstCol) without using the do notation dependent pattern matching technique.
+* ZZGCDOfVectAlg
 
 ## ZZGaussianEliminationLemmas
 
@@ -80,6 +82,10 @@ Table of contents:
 * Lemmas for verifying the euclidean algorithm (bezoutsIdentityZZIfModulo)
 * (bezoutsIdentityZZIfModulo) implementation
 * (Commentary) "Goal: Separation of algorithm from verification."
+
+## ZZGCDOfVectAlg
+
+The extension of a GCD of 2 numbers to that of a Vect of numbers.
 
 ## ZZModuleSpan
 

--- a/ZZBezoutsIdentity.idr
+++ b/ZZBezoutsIdentity.idr
@@ -25,91 +25,10 @@ import Control.Algebra.DiamondInstances
 
 {-
 Table of contents:
-* Some algebra about groups
-* About rings
 * Lemmas for verifying the euclidean algorithm (bezoutsIdentityZZIfModulo)
 * (bezoutsIdentityZZIfModulo) implementation
 * (Commentary) "Goal: Separation of algorithm from verification."
 -}
-
-
-
-{-
-Some algebra about groups
--}
-
-
-
-groupSubtractionIsRDivision : VerifiedGroup t
-	=> {auto ok :
-		((<+>) @{vgrpSemigroupByGrp $ the (VerifiedGroup t) %instance})
-		= ((<+>) @{vgrpSemigroupByVMon $ the (VerifiedGroup t) %instance})
-		}
-	-> (a, b : t)
-	-> (a <-> b) <+> b = a
-groupSubtractionIsRDivision {ok} a b = rewrite ok in
-	trans (sym $ semigroupOpIsAssociative a (inverse b) b)
-	$ trans (cong $ groupInverseIsInverseR b)
-	$ monoidNeutralIsNeutralL a
-
-groupDivisionAddLToSubR : VerifiedGroup t
-	=> {auto ok :
-		((<+>) @{vgrpSemigroupByGrp $ the (VerifiedGroup t) %instance})
-		= ((<+>) @{vgrpSemigroupByVMon $ the (VerifiedGroup t) %instance})
-		}
-	-> (x, y, z : t)
-	-> x <+> y = z
-	-> x = z <-> y
-groupDivisionAddLToSubR {ok} x y z pr
-	= groupOpIsCancellativeR x (z <-> y) y
-	$ trans pr
-	$ sym $ groupSubtractionIsRDivision {ok=ok} z y
-
-inverseIsInvolution : VerifiedGroup t
-	=> (r : t)
-	-> inverse $ inverse r = r
-inverseIsInvolution r = groupOpIsCancellativeR (inverse $ inverse r) r (inverse r)
-	$ trans (groupInverseIsInverseR _)
-	$ sym $ groupInverseIsInverseL _
-
-
-
-{-
-About rings
--}
-
-
-
-ringOpIsDistributiveSubR : VerifiedRing a
-	=> {auto ok :
-		((<+>) @{vrSemigroupByGrp $ the (VerifiedRing a) %instance})
-		= ((<+>) @{vrSemigroupByVMon $ the (VerifiedRing a) %instance})
-		}
-	-> (l, c, r : a)
-	-> (l <-> c) <.> r = l <.> r <-> c <.> r
-ringOpIsDistributiveSubR {ok} l c r =
-	( (l <-> c) <.> r )
-		={ rewrite ok in Refl }=
-	( (l <+> inverse c) <.> r )
-		={ ringOpIsDistributiveR l (inverse c) r }=
-	( l <.> r <+> (inverse c) <.> r )
-		={ rewrite sym ok
-			in cong $ ringNegationCommutesWithRightMult c r }=
-	( l <.> r <-> c <.> r )
-		QED
--- (but true by divisibility of addition even without associativity)
-
-ringOpIsDistributiveSubL : VerifiedRing a
-	=> {auto ok :
-		((<+>) @{vrSemigroupByGrp $ the (VerifiedRing a) %instance})
-		= ((<+>) @{vrSemigroupByVMon $ the (VerifiedRing a) %instance})
-		}
-	-> (l, c, r : a)
-	-> l <.> (c <-> r) = l <.> c <-> l <.> r
-ringOpIsDistributiveSubL {ok} l c r =
-	trans (rewrite ok in ringOpIsDistributiveL l c (inverse r))
-	$ rewrite sym ok in cong $ ringNegationCommutesWithLeftMult l r
--- (but true by divisibility of addition even without associativity)
 
 
 

--- a/ZZGCDOfVectAlg.idr
+++ b/ZZGCDOfVectAlg.idr
@@ -65,45 +65,46 @@ Lemmas about extending a GCD to more than 2 numbers
 
 
 
-lemma1Fn : ( t : Fin n -> ZZ )
+vectGCDFnExtension : ( t : Fin n -> ZZ )
 	-> ( r, r' : ZZ )
 	-> Fin (S n) -> ZZ
-lemma1Fn _ _ r' FZ = r'
-lemma1Fn t r _ (FS prel) = t prel <.> r
+vectGCDFnExtension _ _ r' FZ = r'
+vectGCDFnExtension t r _ (FS prel) = t prel <.> r
 
-lemma1 : ( t : Fin n -> ZZ )
+vectGCDExtension' : ( t : Fin n -> ZZ )
 	-> ( factorizationAtInd : ( j : Fin n )
 		-> t j <.> ( vs <:> xs ) = index j xs )
 	-> ( factorizationX : r' <.> s = x )
 	-> ( factorizationWithin : r <.> s = vs <:> xs )
 	-> ( i : Fin (S n) )
-	-> lemma1Fn t r r' i <.> s = index i (x :: xs)
-lemma1 t factorizationAtInd factorizationX factorizationWithin FZ = factorizationX
-lemma1 t factorizationAtInd factorizationX factorizationWithin (FS prel)
+	-> vectGCDFnExtension t r r' i <.> s = index i (x :: xs)
+vectGCDExtension' t factorizationAtInd factorizationX factorizationWithin FZ
+	= factorizationX
+vectGCDExtension' t factorizationAtInd factorizationX factorizationWithin (FS prel)
 	= trans (sym $ ringOpIsAssociative _ _ _)
 	$ trans (cong factorizationWithin)
 	$ factorizationAtInd prel
 
-lemma1_2 : ( factorizationAtInd : ( j : Fin n )
+vectGCDExtension : ( factorizationAtInd : ( j : Fin n )
 		-> index j xs `quotientOverZZ` ( vs <:> xs ) )
 	-> ( factorizationX : x `quotientOverZZ` s )
 	-> ( factorizationWithin : (vs <:> xs) `quotientOverZZ` s )
 	-> ( i : Fin (S n) )
 	-> index i (x :: xs) `quotientOverZZ` s
-lemma1_2 factorizationAtInd (factnXDiv ** factnXPr) (factnWinDiv ** factnWinPr) i
-	= let lemma1Fn' = \j => getWitness $ factorizationAtInd j
-	in let lemma1Pr = \j => getProof $ factorizationAtInd j
-	in ( lemma1Fn lemma1Fn' factnWinDiv factnXDiv i
-		** lemma1 lemma1Fn' lemma1Pr factnXPr factnWinPr i )
+vectGCDExtension factorizationAtInd (factnXDiv ** factnXPr) (factnWinDiv ** factnWinPr) i
+	= let vectGCDOldFn = \j => getWitness $ factorizationAtInd j
+	in let vectGCDOldPr = \j => getProof $ factorizationAtInd j
+	in ( vectGCDFnExtension vectGCDOldFn factnWinDiv factnXDiv i
+		** vectGCDExtension' vectGCDOldFn vectGCDOldPr factnXPr factnWinPr i )
 
-lemma2 : {a : ZZ}
-	-> a<.>x <+> b<.>(vs <:> xs) = (a :: (b <#> vs)) <:> (x :: xs)
-lemma2 {a} {b} {x} {xs} {vs} = (
-	a<.>x <+> b<.>(vs <:> xs)
-	) ={ cong $ sym vectVectLScalingCompatibility }= (
-	a<.>x <+> ( (b <#> vs)<:>xs )
-	) ={ sym monoidrec1D }= (
+bezoutDotRewrite : {a : ZZ}
+	-> (a :: (b <#> vs)) <:> (x :: xs) = a<.>x <+> b<.>(vs <:> xs)
+bezoutDotRewrite {a} {b} {x} {xs} {vs} = (
 	(a :: (b <#> vs)) <:> (x :: xs)
+	) ={ monoidrec1D }= (
+	a<.>x <+> ( (b <#> vs)<:>xs )
+	) ={ cong vectVectLScalingCompatibility }= (
+	a<.>x <+> b<.>(vs <:> xs)
 	) QED
 
 
@@ -131,16 +132,16 @@ gcdToVectGCD (S predk) (x::xs) with (gcdToVectGCD predk xs)
 	| (vs ** recQFn) = runIdentity $ do {
 			( (a, b) ** (gcdivA, gcdivB) )
 				<- Id $ gcdAlg x (vs <:> xs)
-			let Lem1_2_Ap = lemma1_2
+			let vectGCDExtensionFn = vectGCDExtension
 				{s=a<.>x <+> b<.>(vs <:> xs)}
 				{xs=xs}
 				{vs=vs}
 				{x=x}
 				recQFn gcdivA gcdivB
 			return $ ( a::(b<#>vs) **
-				\i => let apAtI = Lem1_2_Ap i
+				\i => let apAtI = vectGCDExtensionFn i
 				in (getWitness apAtI
-					** trans (cong $ sym lemma2) $ getProof apAtI)
+					** trans (cong bezoutDotRewrite) $ getProof apAtI)
 				)
 		}
 

--- a/ZZGCDOfVectAlg.idr
+++ b/ZZGCDOfVectAlg.idr
@@ -1,0 +1,147 @@
+module ZZGCDOfVectAlg
+
+import Control.Algebra
+import Classes.Verified
+import Control.Algebra.VectorSpace
+
+import Data.ZZ
+import Control.Algebra.NumericInstances
+import Control.Algebra.ZZVerifiedInstances
+
+import Data.Matrix
+import Data.Matrix.Algebraic
+import Data.Matrix.AlgebraicVerified
+import Data.Matrix.LinearCombinations -- for (vectVectLScalingCompatibility)
+
+import Data.Vect.Structural
+
+import ZZDivisors
+
+import FinOrdering
+import FinStructural
+
+import ZZBezoutsIdentity
+
+-- Dependent pattern matching using (do) notation binds improves clarity
+import Control.Monad.Identity
+import Syntax.PreorderReasoning
+
+import Control.Algebra.DiamondInstances
+
+
+
+{-
+Table of contents:
+* Some algebra about Vect groups
+* Lemmas about extending a GCD to more than 2 numbers
+* The extension of a GCD of 2 numbers to that of a Vect of numbers
+-}
+
+
+
+{-
+Some algebra about groups
+-}
+
+
+
+groupSubtractionIsRDivision_Vect : VerifiedGroup t
+	=> {auto ok :
+		((<+>) @{vgrpSemigroupByGrp $ the (VerifiedGroup t) %instance})
+		= ((<+>) @{vgrpSemigroupByVMon $ the (VerifiedGroup t) %instance})
+		}
+	-> (a, b : Vect n t)
+	-> (a <-> b) <+> b = a
+groupSubtractionIsRDivision_Vect [] [] = Refl
+groupSubtractionIsRDivision_Vect (a::as) (b::bs)
+	= vecHeadtailsEq (groupSubtractionIsRDivision a b)
+	$ groupSubtractionIsRDivision_Vect as bs
+
+
+
+{-
+Lemmas about extending a GCD to more than 2 numbers
+-}
+
+
+
+lemma1Fn : ( t : Fin n -> ZZ )
+	-> ( r, r' : ZZ )
+	-> Fin (S n) -> ZZ
+lemma1Fn _ _ r' FZ = r'
+lemma1Fn t r _ (FS prel) = t prel <.> r
+
+lemma1 : ( t : Fin n -> ZZ )
+	-> ( factorizationAtInd : ( j : Fin n )
+		-> t j <.> ( vs <:> xs ) = index j xs )
+	-> ( factorizationX : r' <.> s = x )
+	-> ( factorizationWithin : r <.> s = vs <:> xs )
+	-> ( i : Fin (S n) )
+	-> lemma1Fn t r r' i <.> s = index i (x :: xs)
+lemma1 t factorizationAtInd factorizationX factorizationWithin FZ = factorizationX
+lemma1 t factorizationAtInd factorizationX factorizationWithin (FS prel)
+	= trans (sym $ ringOpIsAssociative _ _ _)
+	$ trans (cong factorizationWithin)
+	$ factorizationAtInd prel
+
+lemma1_2 : ( factorizationAtInd : ( j : Fin n )
+		-> index j xs `quotientOverZZ` ( vs <:> xs ) )
+	-> ( factorizationX : x `quotientOverZZ` s )
+	-> ( factorizationWithin : (vs <:> xs) `quotientOverZZ` s )
+	-> ( i : Fin (S n) )
+	-> index i (x :: xs) `quotientOverZZ` s
+lemma1_2 factorizationAtInd (factnXDiv ** factnXPr) (factnWinDiv ** factnWinPr) i
+	= let lemma1Fn' = \j => getWitness $ factorizationAtInd j
+	in let lemma1Pr = \j => getProof $ factorizationAtInd j
+	in ( lemma1Fn lemma1Fn' factnWinDiv factnXDiv i
+		** lemma1 lemma1Fn' lemma1Pr factnXPr factnWinPr i )
+
+lemma2 : {a : ZZ}
+	-> a<.>x <+> b<.>(vs <:> xs) = (a :: (b <#> vs)) <:> (x :: xs)
+lemma2 {a} {b} {x} {xs} {vs} = (
+	a<.>x <+> b<.>(vs <:> xs)
+	) ={ cong $ sym vectVectLScalingCompatibility }= (
+	a<.>x <+> ( (b <#> vs)<:>xs )
+	) ={ sym monoidrec1D }= (
+	(a :: (b <#> vs)) <:> (x :: xs)
+	) QED
+
+
+
+{-
+The extension of a GCD of 2 numbers to that of a Vect of numbers
+-}
+
+
+
+{- (gcdToVectGCD) parameters -}
+parameters (
+	gcdAlg : (c, d : ZZ)
+		-> ( zpar : (ZZ, ZZ) ** uncurry (bezQTy c d) zpar )
+	) {
+
+gcdToVectGCD :
+	(k : Nat)
+	-> (x : Vect k ZZ)
+	-> ( v : Vect k ZZ **
+		( i : Fin k )
+		-> (index i x) `quotientOverZZ` (v <:> x) )
+gcdToVectGCD Z [] = ( [] ** \i => FinZElim i )
+gcdToVectGCD (S predk) (x::xs) with (gcdToVectGCD predk xs)
+	| (vs ** recQFn) = runIdentity $ do {
+			( (a, b) ** (gcdivA, gcdivB) )
+				<- Id $ gcdAlg x (vs <:> xs)
+			let Lem1_2_Ap = lemma1_2
+				{s=a<.>x <+> b<.>(vs <:> xs)}
+				{xs=xs}
+				{vs=vs}
+				{x=x}
+				recQFn gcdivA gcdivB
+			return $ ( a::(b<#>vs) **
+				\i => let apAtI = Lem1_2_Ap i
+				in (getWitness apAtI
+					** trans (cong $ sym lemma2) $ getProof apAtI)
+				)
+		}
+
+} {- (gcdToVectGCD) parameters -}

--- a/ZZGCDOfVectAlg.idr
+++ b/ZZGCDOfVectAlg.idr
@@ -32,30 +32,9 @@ import Control.Algebra.DiamondInstances
 
 {-
 Table of contents:
-* Some algebra about Vect groups
 * Lemmas about extending a GCD to more than 2 numbers
 * The extension of a GCD of 2 numbers to that of a Vect of numbers
 -}
-
-
-
-{-
-Some algebra about groups
--}
-
-
-
-groupSubtractionIsRDivision_Vect : VerifiedGroup t
-	=> {auto ok :
-		((<+>) @{vgrpSemigroupByGrp $ the (VerifiedGroup t) %instance})
-		= ((<+>) @{vgrpSemigroupByVMon $ the (VerifiedGroup t) %instance})
-		}
-	-> (a, b : Vect n t)
-	-> (a <-> b) <+> b = a
-groupSubtractionIsRDivision_Vect [] [] = Refl
-groupSubtractionIsRDivision_Vect (a::as) (b::bs)
-	= vecHeadtailsEq (groupSubtractionIsRDivision a b)
-	$ groupSubtractionIsRDivision_Vect as bs
 
 
 

--- a/ZZGCDOfVectAlg.idr
+++ b/ZZGCDOfVectAlg.idr
@@ -20,6 +20,10 @@ import ZZDivisors
 import FinOrdering
 import FinStructural
 
+{-
+(bezQTy) is the only thing actually used from here,
+something req.d to potentially generalize to other Bezout domains.
+-}
 import ZZBezoutsIdentity
 
 -- Dependent pattern matching using (do) notation binds improves clarity


### PR DESCRIPTION
* (gaussElimlzIfGCD) now means something different - See applications of (gcdToVectGCD).
  In particular, it refers to the gaussian elimination algorithm generated from the binary GCD, rather than the n-ary GCD.
* Introduced (gcdToVectGCD).
* Moved the new algebra involved in that and (ZZBezoutsIdentity) to Data.Matrix.AlgebraicVerified.